### PR TITLE
Ligther Windows CI

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -23,5 +23,3 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - run: make test
-      - run: make fix
-      - run: git diff HEAD --exit-code --color


### PR DESCRIPTION
The Windows CI is slower than Linux, and at the same time Windows is less compatible. For example, dprint gets confused about Windows line endings. This PR makes the Windows CI only run the essential tests.