### PR TITLE
Make uncompressed releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,5 +60,5 @@ jobs:
           target: ${{ matrix.target }}
           # (required) GitHub token for uploading assets to GitHub Releases.
           token: ${{ secrets.RELEASE_TOKEN }}
-          tar: None
-          zip: None
+          tar: none
+          zip: none

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,3 +60,5 @@ jobs:
           target: ${{ matrix.target }}
           # (required) GitHub token for uploading assets to GitHub Releases.
           token: ${{ secrets.RELEASE_TOKEN }}
+          tar: None
+          zip: None


### PR DESCRIPTION
Distributing the executables in uncompressed form has the advantage that the installer scripts can be simpler and don't have dependencies on unzip, tar, and gz anymore. Run-that-app is all about removing such dependencies. It must be able to run on stripped-down CI systems.