### PR TITLE
Make download URLs testable

### DIFF
--- a/src/apps/alphavet.rs
+++ b/src/apps/alphavet.rs
@@ -75,7 +75,6 @@ fn cpu_text(cpu: Cpu) -> &'static str {
 #[cfg(test)]
 mod tests {
     use crate::detect::{Cpu, Os, Platform};
-    use big_s::S;
 
     #[test]
     fn download_url() {
@@ -84,8 +83,7 @@ mod tests {
             cpu: Cpu::Intel64,
         };
         let have = super::download_url("0.1.0", platform);
-        let want =
-            S("https://github.com/skx/alphavet/releases/download/v0.1.0/alphavet-linux-amd64");
+        let want = "https://github.com/skx/alphavet/releases/download/v0.1.0/alphavet-linux-amd64";
         assert_eq!(have, want);
     }
 }

--- a/src/apps/alphavet.rs
+++ b/src/apps/alphavet.rs
@@ -32,9 +32,13 @@ impl App for Alphavet {
         vec![
             Box::new(DownloadPrecompiledBinary {
                 name: self.name(),
-                url: format!("https://github.com/skx/alphavet/releases/download/v{version}/alphavet-{os}-{cpu}", os = os_text(platform.os), cpu = cpu_text(platform.cpu)),
+                url: download_url(version, platform),
                 artifact_type: ArtifactType::Executable,
-                file_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+                file_on_disk: yard.app_file_path(
+                    self.name(),
+                    version,
+                    self.executable_filename(platform),
+                ),
             }),
             Box::new(CompileFromGoSource {
                 import_path: format!("github.com/skx/alphavet/cmd/alphavet@{version}"),
@@ -43,6 +47,14 @@ impl App for Alphavet {
             }),
         ]
     }
+}
+
+fn download_url(version: &str, platform: Platform) -> String {
+    format!(
+        "https://github.com/skx/alphavet/releases/download/v{version}/alphavet-{os}-{cpu}",
+        os = os_text(platform.os),
+        cpu = cpu_text(platform.cpu)
+    )
 }
 
 fn os_text(os: Os) -> &'static str {
@@ -57,5 +69,23 @@ fn cpu_text(cpu: Cpu) -> &'static str {
     match cpu {
         Cpu::Arm64 => "arm64",
         Cpu::Intel64 => "amd64",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::detect::{Cpu, Os, Platform};
+    use big_s::S;
+
+    #[test]
+    fn download_url() {
+        let platform = Platform {
+            os: Os::Linux,
+            cpu: Cpu::Intel64,
+        };
+        let have = super::download_url("0.1.0", platform);
+        let want =
+            S("https://github.com/skx/alphavet/releases/download/v0.1.0/alphavet-linux-amd64");
+        assert_eq!(have, want);
     }
 }

--- a/src/apps/depth.rs
+++ b/src/apps/depth.rs
@@ -32,9 +32,13 @@ impl App for Depth {
         vec![
             Box::new(DownloadPrecompiledBinary {
                 name: self.name(),
-                url: format!("https://github.com/KyleBanks/depth/releases/download/v{version}/depth_{version}_{os}_{cpu}", os = os_text(platform.os), cpu = cpu_text(platform.cpu)),
+                url: precompiled_url(version, platform),
                 artifact_type: ArtifactType::Executable,
-                file_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+                file_on_disk: yard.app_file_path(
+                    self.name(),
+                    version,
+                    self.executable_filename(platform),
+                ),
             }),
             Box::new(CompileFromGoSource {
                 import_path: format!("github.com/KyleBanks/depth/cmd/depth@v{version}"),
@@ -43,6 +47,10 @@ impl App for Depth {
             }),
         ]
     }
+}
+
+fn precompiled_url(version: &str, platform: Platform) -> String {
+    format!("https://github.com/KyleBanks/depth/releases/download/v{version}/depth_{version}_{os}_{cpu}", os = os_text(platform.os), cpu = cpu_text(platform.cpu))
 }
 
 fn os_text(os: Os) -> &'static str {

--- a/src/apps/depth.rs
+++ b/src/apps/depth.rs
@@ -50,7 +50,11 @@ impl App for Depth {
 }
 
 fn download_url(version: &str, platform: Platform) -> String {
-    format!("https://github.com/KyleBanks/depth/releases/download/v{version}/depth_{version}_{os}_{cpu}", os = os_text(platform.os), cpu = cpu_text(platform.cpu))
+    format!(
+        "https://github.com/KyleBanks/depth/releases/download/v{version}/depth_{version}_{os}_{cpu}",
+        os = os_text(platform.os),
+        cpu = cpu_text(platform.cpu)
+    )
 }
 
 fn os_text(os: Os) -> &'static str {

--- a/src/apps/depth.rs
+++ b/src/apps/depth.rs
@@ -32,7 +32,7 @@ impl App for Depth {
         vec![
             Box::new(DownloadPrecompiledBinary {
                 name: self.name(),
-                url: precompiled_url(version, platform),
+                url: download_url(version, platform),
                 artifact_type: ArtifactType::Executable,
                 file_on_disk: yard.app_file_path(
                     self.name(),
@@ -49,7 +49,7 @@ impl App for Depth {
     }
 }
 
-fn precompiled_url(version: &str, platform: Platform) -> String {
+fn download_url(version: &str, platform: Platform) -> String {
     format!("https://github.com/KyleBanks/depth/releases/download/v{version}/depth_{version}_{os}_{cpu}", os = os_text(platform.os), cpu = cpu_text(platform.cpu))
 }
 
@@ -65,5 +65,22 @@ fn cpu_text(cpu: Cpu) -> &'static str {
     match cpu {
         Cpu::Arm64 => "arm",
         Cpu::Intel64 => "amd64",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::detect::{Cpu, Os, Platform};
+
+    #[test]
+    fn download_url() {
+        let platform = Platform {
+            os: Os::Linux,
+            cpu: Cpu::Intel64,
+        };
+        let have = super::download_url("1.2.1", platform);
+        let want =
+            "https://github.com/KyleBanks/depth/releases/download/v1.2.1/depth_1.2.1_linux_amd64";
+        assert_eq!(have, want);
     }
 }

--- a/src/apps/dprint.rs
+++ b/src/apps/dprint.rs
@@ -33,9 +33,15 @@ impl App for Dprint {
         vec![
             Box::new(DownloadPrecompiledBinary {
                 name: self.name(),
-                url: format!("https://github.com/dprint/dprint/releases/download/{version}/dprint-{cpu}-{os}.zip", os = os_text(platform.os), cpu = cpu_text(platform.cpu)),
-                artifact_type: ArtifactType::Archive { file_to_extract: S(self.executable_filename(platform))},
-                file_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+                url: download_url(version, platform),
+                artifact_type: ArtifactType::Archive {
+                    file_to_extract: S(self.executable_filename(platform)),
+                },
+                file_on_disk: yard.app_file_path(
+                    self.name(),
+                    version,
+                    self.executable_filename(platform),
+                ),
             }),
             Box::new(CompileFromRustSource {
                 crate_name: "dprint",
@@ -44,6 +50,14 @@ impl App for Dprint {
             }),
         ]
     }
+}
+
+fn download_url(version: &str, platform: Platform) -> String {
+    format!(
+        "https://github.com/dprint/dprint/releases/download/{version}/dprint-{cpu}-{os}.zip",
+        os = os_text(platform.os),
+        cpu = cpu_text(platform.cpu)
+    )
 }
 
 fn os_text(os: Os) -> &'static str {

--- a/src/apps/dprint.rs
+++ b/src/apps/dprint.rs
@@ -74,3 +74,19 @@ fn cpu_text(cpu: Cpu) -> &'static str {
         Cpu::Intel64 => "x86_64",
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::detect::{Cpu, Os, Platform};
+
+    #[test]
+    fn download_url() {
+        let platform = Platform {
+            os: Os::MacOS,
+            cpu: Cpu::Arm64,
+        };
+        let have = super::download_url("0.43.0", platform);
+        let want = "https://github.com/dprint/dprint/releases/download/0.43.0/dprint-aarch64-apple-darwin.zip";
+        assert_eq!(have, want);
+    }
+}

--- a/src/apps/gh.rs
+++ b/src/apps/gh.rs
@@ -30,13 +30,28 @@ impl App for Gh {
         vec![
             Box::new(DownloadPrecompiledBinary {
                 name: self.name(),
-                url: format!("https://github.com/cli/cli/releases/download/v{version}/gh_{version}_{os}_{cpu}.{ext}", os = os_text(platform.os), cpu = cpu_text(platform.cpu), ext =ext_text(platform.os)),
-                artifact_type: ArtifactType::Archive { file_to_extract: executable_path(version, platform) },
-                file_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+                url: download_url(version, platform),
+                artifact_type: ArtifactType::Archive {
+                    file_to_extract: executable_path(version, platform),
+                },
+                file_on_disk: yard.app_file_path(
+                    self.name(),
+                    version,
+                    self.executable_filename(platform),
+                ),
             }),
             // installation from source seems more involved, see https://github.com/cli/cli/blob/trunk/docs/source.md
         ]
     }
+}
+
+fn download_url(version: &str, platform: Platform) -> String {
+    format!(
+        "https://github.com/cli/cli/releases/download/v{version}/gh_{version}_{os}_{cpu}.{ext}",
+        os = os_text(platform.os),
+        cpu = cpu_text(platform.cpu),
+        ext = ext_text(platform.os)
+    )
 }
 
 fn executable_path(version: &str, platform: Platform) -> String {
@@ -69,5 +84,22 @@ fn ext_text(os: Os) -> &'static str {
     match os {
         Os::Linux => "tar.gz",
         Os::Windows | Os::MacOS => "zip",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::detect::{Cpu, Os, Platform};
+
+    #[test]
+    fn download_url() {
+        let platform = Platform {
+            os: Os::Linux,
+            cpu: Cpu::Intel64,
+        };
+        let have = super::download_url("2.39.1", platform);
+        let want =
+            "https://github.com/cli/cli/releases/download/v2.39.1/gh_2.39.1_linux_amd64.tar.gz";
+        assert_eq!(have, want);
     }
 }

--- a/src/apps/gofumpt.rs
+++ b/src/apps/gofumpt.rs
@@ -50,7 +50,11 @@ impl App for Gofumpt {
 }
 
 fn download_url(version: &str, platform: Platform) -> String {
-    format!("https://github.com/mvdan/gofumpt/releases/download/v{version}/gofumpt_v{version}_{os}_{cpu}", os = os_text(platform.os), cpu = cpu_text(platform.cpu))
+    format!(
+        "https://github.com/mvdan/gofumpt/releases/download/v{version}/gofumpt_v{version}_{os}_{cpu}",
+        os = os_text(platform.os),
+        cpu = cpu_text(platform.cpu)
+    )
 }
 
 fn os_text(os: Os) -> &'static str {

--- a/src/apps/gofumpt.rs
+++ b/src/apps/gofumpt.rs
@@ -51,9 +51,10 @@ impl App for Gofumpt {
 
 fn download_url(version: &str, platform: Platform) -> String {
     format!(
-        "https://github.com/mvdan/gofumpt/releases/download/v{version}/gofumpt_v{version}_{os}_{cpu}",
+        "https://github.com/mvdan/gofumpt/releases/download/v{version}/gofumpt_v{version}_{os}_{cpu}{ext}",
         os = os_text(platform.os),
-        cpu = cpu_text(platform.cpu)
+        cpu = cpu_text(platform.cpu),
+        ext = ext_text(platform.os)
     )
 }
 
@@ -72,19 +73,40 @@ fn cpu_text(cpu: Cpu) -> &'static str {
     }
 }
 
+fn ext_text(os: Os) -> &'static str {
+    match os {
+        Os::Windows => ".exe",
+        Os::Linux | Os::MacOS => "",
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::detect::{Cpu, Os, Platform};
+    mod download_url {
+        use crate::detect::{Cpu, Os, Platform};
 
-    #[test]
-    fn download_url() {
-        let platform = Platform {
-            os: Os::MacOS,
-            cpu: Cpu::Arm64,
-        };
-        let have = super::download_url("0.5.0", platform);
-        let want =
+        #[test]
+        fn macos_arm64() {
+            let platform = Platform {
+                os: Os::MacOS,
+                cpu: Cpu::Arm64,
+            };
+            let have = super::super::download_url("0.5.0", platform);
+            let want =
             "https://github.com/mvdan/gofumpt/releases/download/v0.5.0/gofumpt_v0.5.0_darwin_arm64";
-        assert_eq!(have, want);
+            assert_eq!(have, want);
+        }
+
+        #[test]
+        fn windows_intel64() {
+            let platform = Platform {
+                os: Os::Windows,
+                cpu: Cpu::Intel64,
+            };
+            let have = super::super::download_url("0.5.0", platform);
+            let want =
+            "https://github.com/mvdan/gofumpt/releases/download/v0.5.0/gofumpt_v0.5.0_windows_amd64.exe";
+            assert_eq!(have, want);
+        }
     }
 }

--- a/src/apps/gofumpt.rs
+++ b/src/apps/gofumpt.rs
@@ -32,17 +32,25 @@ impl App for Gofumpt {
         vec![
             Box::new(DownloadPrecompiledBinary {
                 name: self.name(),
-                url: format!("https://github.com/mvdan/gofumpt/releases/download/v{version}/gofumpt_v{version}_{os}_{cpu}", os = os_text(platform.os), cpu = cpu_text(platform.cpu)),
+                url: download_url(version, platform),
                 artifact_type: ArtifactType::Executable,
-                file_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+                file_on_disk: yard.app_file_path(
+                    self.name(),
+                    version,
+                    self.executable_filename(platform),
+                ),
             }),
             Box::new(CompileFromGoSource {
                 import_path: format!("mvdan.cc/gofumpt@{version}"),
                 target_folder: yard.app_folder(self.name(), version),
                 executable_filename: self.executable_filename(platform),
-             }),
+            }),
         ]
     }
+}
+
+fn download_url(version: &str, platform: Platform) -> String {
+    format!("https://github.com/mvdan/gofumpt/releases/download/v{version}/gofumpt_v{version}_{os}_{cpu}", os = os_text(platform.os), cpu = cpu_text(platform.cpu))
 }
 
 fn os_text(os: Os) -> &'static str {
@@ -57,5 +65,22 @@ fn cpu_text(cpu: Cpu) -> &'static str {
     match cpu {
         Cpu::Arm64 => "arm64",
         Cpu::Intel64 => "amd64",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::detect::{Cpu, Os, Platform};
+
+    #[test]
+    fn download_url() {
+        let platform = Platform {
+            os: Os::MacOS,
+            cpu: Cpu::Arm64,
+        };
+        let have = super::download_url("0.5.0", platform);
+        let want =
+            "https://github.com/mvdan/gofumpt/releases/download/v0.5.0/gofumpt_v0.5.0_darwin_arm64";
+        assert_eq!(have, want);
     }
 }

--- a/src/apps/golangci_lint.rs
+++ b/src/apps/golangci_lint.rs
@@ -51,7 +51,12 @@ impl App for GolangCiLint {
 }
 
 fn download_url(version: &str, platform: Platform) -> String {
-    format!("https://github.com/golangci/golangci-lint/releases/download/v{version}/golangci-lint-{version}-{os}-{cpu}.{ext}",os = os_text(platform.os), cpu =cpu_text(platform.cpu), ext = ext_text(platform.os))
+    format!(
+        "https://github.com/golangci/golangci-lint/releases/download/v{version}/golangci-lint-{version}-{os}-{cpu}.{ext}",
+        os = os_text(platform.os),
+        cpu = cpu_text(platform.cpu),
+        ext = ext_text(platform.os)
+    )
 }
 
 fn os_text(os: Os) -> &'static str {

--- a/src/apps/golangci_lint.rs
+++ b/src/apps/golangci_lint.rs
@@ -27,19 +27,31 @@ impl App for GolangCiLint {
         platform: Platform,
         yard: &Yard,
     ) -> Vec<Box<dyn InstallationMethod>> {
-        let os = os_text(platform.os);
-        let cpu = cpu_text(platform.cpu);
-        let ext = ext_text(platform.os);
         vec![
             Box::new(DownloadPrecompiledBinary {
                 name: self.name(),
-                url: format!("https://github.com/golangci/golangci-lint/releases/download/v{version}/golangci-lint-{version}-{os}-{cpu}.{ext}" ),
-                artifact_type: ArtifactType::Archive { file_to_extract: format!("golangci-lint-{version}-{os}-{cpu}/golangci-lint") },
-                file_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+                url: download_url(version, platform),
+                artifact_type: ArtifactType::Archive {
+                    file_to_extract: format!(
+                        "golangci-lint-{version}-{os}-{cpu}/{executable}",
+                        os = os_text(platform.os),
+                        cpu = cpu_text(platform.cpu),
+                        executable = self.executable_filename(platform)
+                    ),
+                },
+                file_on_disk: yard.app_file_path(
+                    self.name(),
+                    version,
+                    self.executable_filename(platform),
+                ),
             }),
             // install from source not recommended, see https://golangci-lint.run/usage/install/#install-from-source
         ]
     }
+}
+
+fn download_url(version: &str, platform: Platform) -> String {
+    format!("https://github.com/golangci/golangci-lint/releases/download/v{version}/golangci-lint-{version}-{os}-{cpu}.{ext}",os = os_text(platform.os), cpu =cpu_text(platform.cpu), ext = ext_text(platform.os))
 }
 
 fn os_text(os: Os) -> &'static str {
@@ -61,5 +73,22 @@ fn ext_text(os: Os) -> &'static str {
     match os {
         Os::Linux | Os::MacOS => "tar.gz",
         Os::Windows => "zip",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::detect::{Cpu, Os, Platform};
+
+    #[test]
+    fn download_url() {
+        let platform = Platform {
+            os: Os::MacOS,
+            cpu: Cpu::Arm64,
+        };
+        let have = super::download_url("1.55.2", platform);
+        let want =
+            "https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-darwin-arm64.tar.gz";
+        assert_eq!(have, want);
     }
 }

--- a/src/apps/goreleaser.rs
+++ b/src/apps/goreleaser.rs
@@ -56,7 +56,8 @@ fn download_url(version: &str, platform: Platform) -> String {
         "https://github.com/goreleaser/goreleaser/releases/download/v{version}/goreleaser_{os}_{cpu}.{ext}",
         os = os_text(platform.os),
         cpu = cpu_text(platform.cpu),
-        ext = ext_text(platform.os))
+        ext = ext_text(platform.os)
+    )
 }
 
 fn os_text(os: Os) -> &'static str {

--- a/src/apps/goreleaser.rs
+++ b/src/apps/goreleaser.rs
@@ -29,23 +29,34 @@ impl App for Goreleaser {
         platform: Platform,
         yard: &Yard,
     ) -> Vec<Box<dyn InstallationMethod>> {
-        let os = os_text(platform.os);
-        let cpu = cpu_text(platform.cpu);
-        let ext = ext_text(platform.os);
         vec![
             Box::new(DownloadPrecompiledBinary {
                 name: self.name(),
-                url: format!("https://github.com/goreleaser/goreleaser/releases/download/v{version}/goreleaser_{os}_{cpu}.{ext}" ),
-                artifact_type: ArtifactType::Archive { file_to_extract: self.executable_filename(platform).to_string() },
-                file_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+                url: download_url(version, platform),
+                artifact_type: ArtifactType::Archive {
+                    file_to_extract: self.executable_filename(platform).to_string(),
+                },
+                file_on_disk: yard.app_file_path(
+                    self.name(),
+                    version,
+                    self.executable_filename(platform),
+                ),
             }),
             Box::new(CompileFromGoSource {
                 import_path: format!("github.com/goreleaser/goreleaser@{version}"),
                 target_folder: yard.app_folder(self.name(), version),
                 executable_filename: self.executable_filename(platform),
-             }),
+            }),
         ]
     }
+}
+
+fn download_url(version: &str, platform: Platform) -> String {
+    format!(
+        "https://github.com/goreleaser/goreleaser/releases/download/v{version}/goreleaser_{os}_{cpu}.{ext}",
+        os = os_text(platform.os),
+        cpu = cpu_text(platform.cpu),
+        ext = ext_text(platform.os))
 }
 
 fn os_text(os: Os) -> &'static str {
@@ -67,5 +78,21 @@ fn ext_text(os: Os) -> &'static str {
     match os {
         Os::Linux | Os::MacOS => "tar.gz",
         Os::Windows => "zip",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::detect::{Cpu, Os, Platform};
+
+    #[test]
+    fn download_url() {
+        let platform = Platform {
+            os: Os::MacOS,
+            cpu: Cpu::Arm64,
+        };
+        let have = super::download_url("1.22.1", platform);
+        let want = "https://github.com/goreleaser/goreleaser/releases/download/v1.22.1/goreleaser_Darwin_arm64.tar.gz";
+        assert_eq!(have, want);
     }
 }


### PR DESCRIPTION
This helps making the download robust and testable without having to depend on unreliable external servers. The download URLs in the tests are the copy-pasted actual URLs, not synthetic test data.