### PR TITLE
Simplify Yard API

### DIFF
--- a/src/apps/actionlint.rs
+++ b/src/apps/actionlint.rs
@@ -34,7 +34,7 @@ impl App for ActionLint {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
             file_to_extract: self.executable_filename(platform),
-            filepath_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(self.name(), version).join(self.executable_filename(platform)),
             output,
         })? {
             return Ok(Some(executable));

--- a/src/apps/depth.rs
+++ b/src/apps/depth.rs
@@ -33,7 +33,7 @@ impl App for Depth {
         if let Some(executable) = executable::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
-            filepath_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(self.name(), version).join(self.executable_filename(platform)),
             output,
         })? {
             return Ok(Some(executable));

--- a/src/apps/dprint.rs
+++ b/src/apps/dprint.rs
@@ -33,7 +33,7 @@ impl App for Dprint {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
             file_to_extract: self.executable_filename(platform),
-            filepath_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(self.name(), version).join(self.executable_filename(platform)),
             output,
         })? {
             return Ok(Some(executable));

--- a/src/apps/gh.rs
+++ b/src/apps/gh.rs
@@ -32,7 +32,7 @@ impl App for Gh {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
             file_to_extract: &executable_path(version, platform),
-            filepath_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(self.name(), version).join(self.executable_filename(platform)),
             output,
         })
         // installation from source seems more involved, see https://github.com/cli/cli/blob/trunk/docs/source.md

--- a/src/apps/ghokin.rs
+++ b/src/apps/ghokin.rs
@@ -34,7 +34,7 @@ impl App for Ghokin {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
             file_to_extract: self.executable_filename(platform),
-            filepath_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(self.name(), version).join(self.executable_filename(platform)),
             output,
         })? {
             return Ok(Some(executable));

--- a/src/apps/gofmt.rs
+++ b/src/apps/gofmt.rs
@@ -26,7 +26,7 @@ impl App for Gofmt {
     fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let go = Go {};
         go.install(version, platform, yard, output)?;
-        let executable_path = yard.app_file_path(go.name(), version, self.executable_filename(platform));
+        let executable_path = yard.app_folder(go.name(), version).join(self.executable_filename(platform));
         Ok(Some(Executable(executable_path)))
     }
 

--- a/src/apps/gofumpt.rs
+++ b/src/apps/gofumpt.rs
@@ -37,7 +37,7 @@ impl App for Gofumpt {
         if let Some(executable) = executable::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
-            filepath_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(self.name(), version).join(self.executable_filename(platform)),
             output,
         })? {
             return Ok(Some(executable));

--- a/src/apps/golangci_lint.rs
+++ b/src/apps/golangci_lint.rs
@@ -33,7 +33,7 @@ impl App for GolangCiLint {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
             file_to_extract: &executable_path(version, platform, self.executable_filename(platform)),
-            filepath_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(self.name(), version).join(self.executable_filename(platform)),
             output,
         })
         // install from source not recommended, see https://golangci-lint.run/usage/install/#install-from-source

--- a/src/apps/goreleaser.rs
+++ b/src/apps/goreleaser.rs
@@ -33,7 +33,7 @@ impl App for Goreleaser {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
             file_to_extract: self.executable_filename(platform),
-            filepath_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(self.name(), version).join(self.executable_filename(platform)),
             output,
         })? {
             return Ok(Some(executable));

--- a/src/apps/mdbook.rs
+++ b/src/apps/mdbook.rs
@@ -34,7 +34,7 @@ impl App for MdBook {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
             file_to_extract: self.executable_filename(platform),
-            filepath_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(self.name(), version).join(self.executable_filename(platform)),
             output,
         })? {
             return Ok(Some(executable));

--- a/src/apps/npm.rs
+++ b/src/apps/npm.rs
@@ -26,7 +26,7 @@ impl App for Npm {
     fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let nodejs = NodeJS {};
         nodejs.install(version, platform, yard, output)?;
-        let executable_path = yard.app_file_path(nodejs.name(), version, self.executable_filename(platform));
+        let executable_path = yard.app_folder(nodejs.name(), version).join(self.executable_filename(platform));
         Ok(Some(Executable(executable_path)))
     }
 

--- a/src/apps/npx.rs
+++ b/src/apps/npx.rs
@@ -26,7 +26,7 @@ impl App for Npx {
     fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let nodejs = NodeJS {};
         nodejs.install(version, platform, yard, output)?;
-        let executable_path = yard.app_file_path(nodejs.name(), version, self.executable_filename(platform));
+        let executable_path = yard.app_folder(nodejs.name(), version).join(self.executable_filename(platform));
         Ok(Some(Executable(executable_path)))
     }
 

--- a/src/apps/scc.rs
+++ b/src/apps/scc.rs
@@ -34,7 +34,7 @@ impl App for Scc {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
             file_to_extract: self.executable_filename(platform),
-            filepath_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(self.name(), version).join(self.executable_filename(platform)),
             output,
         })? {
             return Ok(Some(executable));

--- a/src/apps/shellcheck.rs
+++ b/src/apps/shellcheck.rs
@@ -32,7 +32,7 @@ impl App for ShellCheck {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
             file_to_extract: &format!("shellcheck-v{version}/{executable}", executable = self.executable_filename(platform)),
-            filepath_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(self.name(), version).join(self.executable_filename(platform)),
             output,
         })
     }

--- a/src/apps/shfmt.rs
+++ b/src/apps/shfmt.rs
@@ -33,7 +33,7 @@ impl App for Shfmt {
         if let Some(executable) = executable::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
-            filepath_on_disk: yard.app_file_path(self.name(), version, self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(self.name(), version).join(self.executable_filename(platform)),
             output,
         })? {
             return Ok(Some(executable));

--- a/src/yard/yard.rs
+++ b/src/yard/yard.rs
@@ -11,11 +11,6 @@ pub struct Yard {
 
 /// stores executables of and metadata about applications
 impl Yard {
-    /// provides the path to the given file that is part of the given application
-    pub fn app_file_path(&self, app_name: &str, app_version: &str, file: &str) -> PathBuf {
-        self.app_folder(app_name, app_version).join(file)
-    }
-
     /// provides the path to the folder containing the given application
     pub fn app_folder(&self, app_name: &str, app_version: &str) -> PathBuf {
         self.root.join("apps").join(app_name).join(app_version)
@@ -27,7 +22,7 @@ impl Yard {
 
     /// provides the path to the executable of the given application
     pub fn load_app(&self, name: &str, version: &str, executable_filename: &str) -> Option<Executable> {
-        let file_path = self.app_file_path(name, version, executable_filename);
+        let file_path = self.app_folder(name, version).join(executable_filename);
         if file_path.exists() {
             Some(Executable(file_path))
         } else {
@@ -58,7 +53,7 @@ impl Yard {
     fn save_app_file(&self, name: &str, version: &str, file_name: &str, file_content: &[u8]) {
         use std::io::Write;
         fs::create_dir_all(self.app_folder(name, version)).unwrap();
-        let mut file = fs::File::create(self.app_file_path(name, version, file_name)).unwrap();
+        let mut file = fs::File::create(self.app_folder(name, version).join(file_name)).unwrap();
         file.write_all(file_content).unwrap();
     }
 }
@@ -71,7 +66,7 @@ mod tests {
     #[test]
     fn app_file_path() {
         let yard = Yard { root: PathBuf::from("/root") };
-        let have = yard.app_file_path("shellcheck", "0.9.0", "shellcheck.exe");
+        let have = yard.app_folder("shellcheck", "0.9.0").join("shellcheck.exe");
         let want = PathBuf::from("/root/apps/shellcheck/0.9.0/shellcheck.exe");
         assert_eq!(have, want);
     }


### PR DESCRIPTION
The `app_file_path` method is too specific and can be replaced with the existing `app_folder` API. This also leads to better readable code that avoids three string arguments.