### PR TITLE
Move AppVersion to config module

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,6 +1,6 @@
-use super::AppVersion;
 use super::Command;
 use crate::cmd::run;
+use crate::config::AppVersion;
 use crate::{Result, UserError};
 
 /// all arguments that can be provided via the CLI
@@ -155,13 +155,15 @@ mod tests {
             use big_s::S;
 
             use super::parse_args;
-            use crate::cli::{AppVersion, Args, Command};
+            use crate::cli::{Args, Command};
             use crate::cmd::run;
+            use crate::config::AppVersion;
             use crate::error::UserError;
 
             mod available {
                 use super::super::parse_args;
-                use crate::cli::{AppVersion, Args, Command};
+                use crate::cli::{Args, Command};
+                use crate::config::AppVersion;
                 use crate::error::UserError;
                 use big_s::S;
 
@@ -207,8 +209,9 @@ mod tests {
 
             mod error_on_output {
                 use super::super::parse_args;
-                use crate::cli::{AppVersion, Args, Command};
+                use crate::cli::{Args, Command};
                 use crate::cmd::run;
+                use crate::config::AppVersion;
                 use crate::error::UserError;
                 use big_s::S;
 
@@ -262,8 +265,9 @@ mod tests {
 
             mod include_path {
                 use super::super::parse_args;
-                use crate::cli::{AppVersion, Args, Command};
+                use crate::cli::{Args, Command};
                 use crate::cmd::run;
+                use crate::config::AppVersion;
                 use crate::UserError;
                 use big_s::S;
 
@@ -298,8 +302,9 @@ mod tests {
 
             mod log {
                 use super::super::parse_args;
-                use crate::cli::{AppVersion, Args, Command};
+                use crate::cli::{Args, Command};
                 use crate::cmd::run;
+                use crate::config::AppVersion;
                 use crate::error::UserError;
                 use big_s::S;
 
@@ -443,7 +448,8 @@ mod tests {
 
             mod which {
                 use super::super::parse_args;
-                use crate::cli::{AppVersion, Args, Command};
+                use crate::cli::{Args, Command};
+                use crate::config::AppVersion;
                 use crate::UserError;
                 use big_s::S;
 
@@ -490,8 +496,9 @@ mod tests {
 
         mod application_arguments {
             use super::parse_args;
-            use crate::cli::{args, AppVersion, Command};
+            use crate::cli::{args, Command};
             use crate::cmd::run;
+            use crate::config::AppVersion;
             use args::Args;
             use big_s::S;
 
@@ -540,8 +547,9 @@ mod tests {
 
         mod rta_and_app_arguments {
             use super::parse_args;
-            use crate::cli::{AppVersion, Args, Command};
+            use crate::cli::{Args, Command};
             use crate::cmd::run;
+            use crate::config::AppVersion;
             use big_s::S;
 
             #[test]

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -1,5 +1,5 @@
-use super::AppVersion;
 use crate::cmd::run;
+use crate::config::AppVersion;
 
 /// the main commands that run-this-app can execute
 #[derive(Debug, PartialEq)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,10 +1,8 @@
 //! CLI arguments
 
-mod app_version;
 mod args;
 mod command;
 
-pub use app_version::AppVersion;
 pub use args::parse;
 #[cfg(test)]
 pub use args::Args;

--- a/src/cmd/available.rs
+++ b/src/cmd/available.rs
@@ -1,5 +1,5 @@
 use super::run::load_or_install;
-use crate::cli::AppVersion;
+use crate::config::AppVersion;
 use crate::Output;
 use crate::Result;
 use std::process::ExitCode;

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -1,5 +1,5 @@
 use crate::apps;
-use crate::cli::AppVersion;
+use crate::config::AppVersion;
 use crate::config;
 use crate::error::UserError;
 use crate::filesystem::find_global_install;

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -1,5 +1,4 @@
-use crate::cli::AppVersion;
-use crate::config::Config;
+use crate::config::{AppVersion, Config};
 use crate::output::Output;
 use crate::Result;
 use crate::{apps, config};

--- a/src/cmd/which.rs
+++ b/src/cmd/which.rs
@@ -1,4 +1,4 @@
-use crate::cli::AppVersion;
+use crate::config::AppVersion;
 use crate::Output;
 use crate::Result;
 use std::process::ExitCode;

--- a/src/config/app_version.rs
+++ b/src/config/app_version.rs
@@ -18,7 +18,7 @@ impl AppVersion {
 #[cfg(test)]
 mod tests {
     mod parse {
-        use crate::cli::AppVersion;
+        use crate::config::AppVersion;
         use big_s::S;
 
         #[test]

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -1,4 +1,4 @@
-use crate::cli::AppVersion;
+use crate::config::AppVersion;
 use std::fmt::Display;
 
 #[derive(Debug, Default, PartialEq)]

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -1,6 +1,6 @@
 use super::Config;
 use super::FILE_NAME;
-use crate::cli::AppVersion;
+use crate::config::AppVersion;
 use crate::Result;
 use crate::UserError;
 use std::env;
@@ -102,8 +102,7 @@ mod tests {
 
     mod parse {
         use super::super::parse;
-        use crate::cli::AppVersion;
-        use crate::config::Config;
+        use crate::config::{AppVersion,Config};
         use big_s::S;
 
         #[test]
@@ -134,7 +133,7 @@ mod tests {
 
     mod parse_line {
         use super::super::parse_line;
-        use crate::cli::AppVersion;
+        use crate::config::AppVersion;
         use crate::error::UserError;
         use big_s::S;
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,10 +1,12 @@
 //! functionality for the `.tool-versions` file
 
+mod app_version;
 mod config;
 mod create;
 mod load;
 mod save;
 
+pub use app_version::AppVersion;
 pub use config::Config;
 pub use create::create;
 pub use load::load;

--- a/src/yard/yard.rs
+++ b/src/yard/yard.rs
@@ -1,4 +1,4 @@
-use crate::cli::AppVersion;
+use crate::config::AppVersion;
 use crate::error::UserError;
 use crate::subshell::Executable;
 use crate::Result;
@@ -80,7 +80,7 @@ mod tests {
     }
 
     mod is_not_installable {
-        use crate::cli::AppVersion;
+        use crate::config::AppVersion;
         use crate::yard::create;
         use crate::yard::Yard;
         use big_s::S;
@@ -112,7 +112,7 @@ mod tests {
     }
 
     mod load_app {
-        use crate::cli::AppVersion;
+        use crate::config::AppVersion;
         use crate::subshell::Executable;
         use crate::yard::{create, Yard};
         use big_s::S;


### PR DESCRIPTION
It belongs semantically to the config data more than to the CLI data. AppVersions are part of the configuration. The CLI merely reads this config from CLI arguments.