### PR TITLE
NewType for version

### DIFF
--- a/src/apps/actionlint.rs
+++ b/src/apps/actionlint.rs
@@ -67,7 +67,7 @@ fn download_url(version: &Version, platform: Platform) -> String {
         "https://github.com/{ORG}/{REPO}/releases/download/v{version}/actionlint_{version}_{os}_{cpu}.{ext}",
         os = os_text(platform.os),
         cpu = cpu_text(platform.cpu),
-        ext = ext_text(platform.os),
+        ext = ext_text(platform.os)
     )
 }
 

--- a/src/apps/actionlint.rs
+++ b/src/apps/actionlint.rs
@@ -95,7 +95,6 @@ fn ext_text(os: Os) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::Version;
     use crate::platform::{Cpu, Os, Platform};
 
     #[test]
@@ -104,7 +103,7 @@ mod tests {
             os: Os::Linux,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url(&Version::from("1.6.26"), platform);
+        let have = super::download_url(&"1.6.26".into(), platform);
         let want = "https://github.com/rhysd/actionlint/releases/download/v1.6.26/actionlint_1.6.26_linux_arm64.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/actionlint.rs
+++ b/src/apps/actionlint.rs
@@ -49,7 +49,7 @@ impl App for ActionLint {
         })
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         github_releases::latest(ORG, REPO, output)
     }
 
@@ -57,7 +57,7 @@ impl App for ActionLint {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         github_releases::versions(ORG, REPO, amount, output)
     }
 }

--- a/src/apps/actionlint.rs
+++ b/src/apps/actionlint.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_releases;
 use crate::install::compile_go::{compile_go, CompileArgs};
 use crate::install::packaged_executable::{self, InstallArgs};
@@ -29,7 +30,7 @@ impl App for ActionLint {
         formatcp!("https://{ORG}.github.io/{REPO}")
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let result = packaged_executable::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
@@ -52,7 +53,7 @@ impl App for ActionLint {
         github_releases::latest(ORG, REPO, output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
@@ -61,12 +62,12 @@ impl App for ActionLint {
     }
 }
 
-fn download_url(version: &str, platform: Platform) -> String {
+fn download_url(version: &Version, platform: Platform) -> String {
     format!(
         "https://github.com/{ORG}/{REPO}/releases/download/v{version}/actionlint_{version}_{os}_{cpu}.{ext}",
         os = os_text(platform.os),
         cpu = cpu_text(platform.cpu),
-        ext = ext_text(platform.os)
+        ext = ext_text(platform.os),
     )
 }
 
@@ -94,6 +95,7 @@ fn ext_text(os: Os) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::Version;
     use crate::platform::{Cpu, Os, Platform};
 
     #[test]
@@ -102,7 +104,7 @@ mod tests {
             os: Os::Linux,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url("1.6.26", platform);
+        let have = super::download_url(&Version::from("1.6.26"), platform);
         let want = "https://github.com/rhysd/actionlint/releases/download/v1.6.26/actionlint_1.6.26_linux_arm64.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/actionlint.rs
+++ b/src/apps/actionlint.rs
@@ -95,6 +95,7 @@ fn ext_text(os: Os) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::Version;
     use crate::platform::{Cpu, Os, Platform};
 
     #[test]
@@ -103,7 +104,7 @@ mod tests {
             os: Os::Linux,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url(&"1.6.26".into(), platform);
+        let have = super::download_url(&Version::from("1.6.26"), platform);
         let want = "https://github.com/rhysd/actionlint/releases/download/v1.6.26/actionlint_1.6.26_linux_arm64.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/alphavet.rs
+++ b/src/apps/alphavet.rs
@@ -39,7 +39,7 @@ impl App for Alphavet {
         })
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         github_releases::latest(ORG, REPO, output)
     }
 
@@ -47,7 +47,7 @@ impl App for Alphavet {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         github_releases::versions(ORG, REPO, amount, output)
     }
 }

--- a/src/apps/alphavet.rs
+++ b/src/apps/alphavet.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_releases;
 use crate::install::compile_go::{compile_go, CompileArgs};
 use crate::platform::{Os, Platform};
@@ -28,7 +29,7 @@ impl App for Alphavet {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         // the precompiled binaries are crashing on Linux
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}/cmd/alphavet@v{version}"),
@@ -42,7 +43,7 @@ impl App for Alphavet {
         github_releases::latest(ORG, REPO, output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 

--- a/src/apps/deadcode.rs
+++ b/src/apps/deadcode.rs
@@ -5,7 +5,6 @@ use crate::platform::{Os, Platform};
 use crate::subshell::Executable;
 use crate::yard::Yard;
 use crate::{Output, Result};
-use big_s::S;
 use const_format::formatcp;
 
 pub struct Deadcode {}
@@ -35,16 +34,16 @@ impl App for Deadcode {
         })
     }
 
-    fn latest_installable_version(&self, _output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, _output: &dyn Output) -> Result<Version> {
         // TODO: remove this file once deadcode is integrated into golangci-lint
-        Ok(S("0.16.1"))
+        Ok("0.16.1".into())
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, _amount: usize, _output: &dyn Output) -> Result<Vec<String>> {
-        Ok(vec![S("0.16.1")])
+    fn installable_versions(&self, _amount: usize, _output: &dyn Output) -> Result<Vec<Version>> {
+        Ok(vec!["0.16.1".into()])
     }
 }

--- a/src/apps/deadcode.rs
+++ b/src/apps/deadcode.rs
@@ -36,7 +36,7 @@ impl App for Deadcode {
 
     fn latest_installable_version(&self, _output: &dyn Output) -> Result<Version> {
         // TODO: remove this file once deadcode is integrated into golangci-lint
-        Ok("0.16.1".into())
+        Ok(Version::from("0.16.1"))
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
@@ -44,6 +44,6 @@ impl App for Deadcode {
     }
 
     fn installable_versions(&self, _amount: usize, _output: &dyn Output) -> Result<Vec<Version>> {
-        Ok(vec!["0.16.1".into()])
+        Ok(vec![Version::from("0.16.1")])
     }
 }

--- a/src/apps/deadcode.rs
+++ b/src/apps/deadcode.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::install::compile_go::{compile_go, CompileArgs};
 use crate::platform::{Os, Platform};
 use crate::subshell::Executable;
@@ -25,7 +26,7 @@ impl App for Deadcode {
         formatcp!("https://pkg.go.dev/golang.org/x/tools/cmd/deadcode")
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         compile_go(CompileArgs {
             import_path: format!("golang.org/x/tools/cmd/deadcode@v{version}"),
             target_folder: &yard.app_folder(self.name(), version),
@@ -39,7 +40,7 @@ impl App for Deadcode {
         Ok(S("0.16.1"))
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 

--- a/src/apps/depth.rs
+++ b/src/apps/depth.rs
@@ -86,6 +86,7 @@ fn cpu_text(cpu: Cpu) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::Version;
     use crate::platform::{Cpu, Os, Platform};
 
     #[test]
@@ -94,7 +95,7 @@ mod tests {
             os: Os::Linux,
             cpu: Cpu::Intel64,
         };
-        let have = super::download_url(&"1.2.1".into(), platform);
+        let have = super::download_url(&Version::from("1.2.1"), platform);
         let want = "https://github.com/KyleBanks/depth/releases/download/v1.2.1/depth_1.2.1_linux_amd64";
         assert_eq!(have, want);
     }

--- a/src/apps/depth.rs
+++ b/src/apps/depth.rs
@@ -48,7 +48,7 @@ impl App for Depth {
         })
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         github_releases::latest(ORG, REPO, output)
     }
 
@@ -56,7 +56,7 @@ impl App for Depth {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         github_releases::versions(ORG, REPO, amount, output)
     }
 }

--- a/src/apps/depth.rs
+++ b/src/apps/depth.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_releases;
 use crate::install::compile_go::{compile_go, CompileArgs};
 use crate::install::executable::{self, InstallArgs};
@@ -29,7 +30,7 @@ impl App for Depth {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let result = executable::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
@@ -51,7 +52,7 @@ impl App for Depth {
         github_releases::latest(ORG, REPO, output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
@@ -60,7 +61,7 @@ impl App for Depth {
     }
 }
 
-fn download_url(version: &str, platform: Platform) -> String {
+fn download_url(version: &Version, platform: Platform) -> String {
     format!(
         "https://github.com/{ORG}/{REPO}/releases/download/v{version}/depth_{version}_{os}_{cpu}",
         os = os_text(platform.os),
@@ -93,7 +94,7 @@ mod tests {
             os: Os::Linux,
             cpu: Cpu::Intel64,
         };
-        let have = super::download_url("1.2.1", platform);
+        let have = super::download_url(&"1.2.1".into(), platform);
         let want = "https://github.com/KyleBanks/depth/releases/download/v1.2.1/depth_1.2.1_linux_amd64";
         assert_eq!(have, want);
     }

--- a/src/apps/dprint.rs
+++ b/src/apps/dprint.rs
@@ -48,7 +48,7 @@ impl App for Dprint {
         })
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         github_releases::latest(ORG, REPO, output)
     }
 
@@ -56,7 +56,7 @@ impl App for Dprint {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         github_releases::versions(ORG, REPO, amount, output)
     }
 }

--- a/src/apps/dprint.rs
+++ b/src/apps/dprint.rs
@@ -86,6 +86,7 @@ fn cpu_text(cpu: Cpu) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::Version;
     use crate::platform::{Cpu, Os, Platform};
 
     #[test]
@@ -94,7 +95,7 @@ mod tests {
             os: Os::MacOS,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url(&"0.43.0".into(), platform);
+        let have = super::download_url(&Version::from("0.43.0"), platform);
         let want = "https://github.com/dprint/dprint/releases/download/0.43.0/dprint-aarch64-apple-darwin.zip";
         assert_eq!(have, want);
     }
@@ -105,7 +106,7 @@ mod tests {
             os: Os::Linux,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url(&"0.43.1".into(), platform);
+        let have = super::download_url(&Version::from("0.43.1"), platform);
         let want = "https://github.com/dprint/dprint/releases/download/0.43.1/dprint-aarch64-unknown-linux-gnu.zip";
         assert_eq!(have, want);
     }

--- a/src/apps/dprint.rs
+++ b/src/apps/dprint.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_releases;
 use crate::install::compile_rust::{compile_rust, CompileArgs};
 use crate::install::packaged_executable::{self, InstallArgs};
@@ -28,7 +29,7 @@ impl App for Dprint {
         "https://dprint.dev"
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let result = packaged_executable::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
@@ -51,7 +52,7 @@ impl App for Dprint {
         github_releases::latest(ORG, REPO, output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
@@ -60,7 +61,7 @@ impl App for Dprint {
     }
 }
 
-fn download_url(version: &str, platform: Platform) -> String {
+fn download_url(version: &Version, platform: Platform) -> String {
     format!(
         "https://github.com/{ORG}/{REPO}/releases/download/{version}/dprint-{cpu}-{os}.zip",
         os = os_text(platform.os),
@@ -93,7 +94,7 @@ mod tests {
             os: Os::MacOS,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url("0.43.0", platform);
+        let have = super::download_url(&"0.43.0".into(), platform);
         let want = "https://github.com/dprint/dprint/releases/download/0.43.0/dprint-aarch64-apple-darwin.zip";
         assert_eq!(have, want);
     }
@@ -104,7 +105,7 @@ mod tests {
             os: Os::Linux,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url("0.43.1", platform);
+        let have = super::download_url(&"0.43.1".into(), platform);
         let want = "https://github.com/dprint/dprint/releases/download/0.43.1/dprint-aarch64-unknown-linux-gnu.zip";
         assert_eq!(have, want);
     }

--- a/src/apps/gh.rs
+++ b/src/apps/gh.rs
@@ -39,7 +39,7 @@ impl App for Gh {
         // installation from source seems more involved, see https://github.com/cli/cli/blob/trunk/docs/source.md
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         github_releases::latest(ORG, REPO, output)
     }
 
@@ -47,7 +47,7 @@ impl App for Gh {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         github_releases::versions(ORG, REPO, amount, output)
     }
 }

--- a/src/apps/gh.rs
+++ b/src/apps/gh.rs
@@ -92,6 +92,7 @@ fn ext_text(os: Os) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::Version;
     use crate::platform::{Cpu, Os, Platform};
 
     #[test]
@@ -100,7 +101,7 @@ mod tests {
             os: Os::Linux,
             cpu: Cpu::Intel64,
         };
-        let have = super::download_url(&"2.39.1".into(), platform);
+        let have = super::download_url(&Version::from("2.39.1"), platform);
         let want = "https://github.com/cli/cli/releases/download/v2.39.1/gh_2.39.1_linux_amd64.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/gh.rs
+++ b/src/apps/gh.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_releases;
 use crate::install::packaged_executable::{self, InstallArgs};
 use crate::platform::{Cpu, Os, Platform};
@@ -27,7 +28,7 @@ impl App for Gh {
         "https://cli.github.com"
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         packaged_executable::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
@@ -42,7 +43,7 @@ impl App for Gh {
         github_releases::latest(ORG, REPO, output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
@@ -51,7 +52,7 @@ impl App for Gh {
     }
 }
 
-fn download_url(version: &str, platform: Platform) -> String {
+fn download_url(version: &Version, platform: Platform) -> String {
     format!(
         "https://github.com/{ORG}/{REPO}/releases/download/v{version}/gh_{version}_{os}_{cpu}.{ext}",
         os = os_text(platform.os),
@@ -60,7 +61,7 @@ fn download_url(version: &str, platform: Platform) -> String {
     )
 }
 
-fn executable_path(version: &str, platform: Platform) -> String {
+fn executable_path(version: &Version, platform: Platform) -> String {
     match platform.os {
         Os::Windows => "bin/gh.exe".to_string(),
         Os::Linux | Os::MacOS => format!("gh_{version}_{os}_{cpu}/bin/gh", os = os_text(platform.os), cpu = cpu_text(platform.cpu)),
@@ -99,7 +100,7 @@ mod tests {
             os: Os::Linux,
             cpu: Cpu::Intel64,
         };
-        let have = super::download_url("2.39.1", platform);
+        let have = super::download_url(&"2.39.1".into(), platform);
         let want = "https://github.com/cli/cli/releases/download/v2.39.1/gh_2.39.1_linux_amd64.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/ghokin.rs
+++ b/src/apps/ghokin.rs
@@ -49,7 +49,7 @@ impl App for Ghokin {
         })
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         github_releases::latest(ORG, REPO, output)
     }
 
@@ -57,7 +57,7 @@ impl App for Ghokin {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         github_releases::versions("antham", "ghokin", amount, output)
     }
 }

--- a/src/apps/ghokin.rs
+++ b/src/apps/ghokin.rs
@@ -88,6 +88,7 @@ fn cpu_text(cpu: Cpu) -> &'static str {
 #[cfg(test)]
 mod tests {
     mod download_url {
+        use crate::config::Version;
         use crate::platform::{Cpu, Os, Platform};
 
         #[test]
@@ -96,7 +97,7 @@ mod tests {
                 os: Os::MacOS,
                 cpu: Cpu::Intel64,
             };
-            let have = super::super::download_url(&"3.4.1".into(), platform);
+            let have = super::super::download_url(&Version::from("3.4.1"), platform);
             let want = "https://github.com/antham/ghokin/releases/download/v3.4.1/ghokin_3.4.1_darwin_amd64.tar.gz";
             assert_eq!(have, want);
         }
@@ -107,7 +108,7 @@ mod tests {
                 os: Os::Windows,
                 cpu: Cpu::Intel64,
             };
-            let have = super::super::download_url(&"3.4.1".into(), platform);
+            let have = super::super::download_url(&Version::from("3.4.1"), platform);
             let want = "https://github.com/antham/ghokin/releases/download/v3.4.1/ghokin_3.4.1_windows_amd64.tar.gz";
             assert_eq!(have, want);
         }

--- a/src/apps/ghokin.rs
+++ b/src/apps/ghokin.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_releases;
 use crate::install::compile_go::{compile_go, CompileArgs};
 use crate::install::packaged_executable::{self, InstallArgs};
@@ -29,7 +30,7 @@ impl App for Ghokin {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let result = packaged_executable::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
@@ -52,7 +53,7 @@ impl App for Ghokin {
         github_releases::latest(ORG, REPO, output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
@@ -61,7 +62,7 @@ impl App for Ghokin {
     }
 }
 
-fn download_url(version: &str, platform: Platform) -> String {
+fn download_url(version: &Version, platform: Platform) -> String {
     format!(
         "https://github.com/{ORG}/{REPO}/releases/download/v{version}/ghokin_{version}_{os}_{cpu}.tar.gz",
         os = os_text(platform.os),
@@ -95,7 +96,7 @@ mod tests {
                 os: Os::MacOS,
                 cpu: Cpu::Intel64,
             };
-            let have = super::super::download_url("3.4.1", platform);
+            let have = super::super::download_url(&"3.4.1".into(), platform);
             let want = "https://github.com/antham/ghokin/releases/download/v3.4.1/ghokin_3.4.1_darwin_amd64.tar.gz";
             assert_eq!(have, want);
         }
@@ -106,7 +107,7 @@ mod tests {
                 os: Os::Windows,
                 cpu: Cpu::Intel64,
             };
-            let have = super::super::download_url("3.4.1", platform);
+            let have = super::super::download_url(&"3.4.1".into(), platform);
             let want = "https://github.com/antham/ghokin/releases/download/v3.4.1/ghokin_3.4.1_windows_amd64.tar.gz";
             assert_eq!(have, want);
         }

--- a/src/apps/go.rs
+++ b/src/apps/go.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_tags;
 use crate::install::archive::{self, InstallArgs};
 use crate::platform::{Cpu, Os, Platform};
@@ -28,7 +29,7 @@ impl App for Go {
         "https://go.dev"
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         archive::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
@@ -44,7 +45,7 @@ impl App for Go {
         Ok(versions.into_iter().next().unwrap())
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, &self.executable_path(platform))
     }
 
@@ -69,7 +70,7 @@ impl Go {
     }
 }
 
-pub fn download_url(version: &str, platform: Platform) -> String {
+pub fn download_url(version: &Version, platform: Platform) -> String {
     format!(
         "https://go.dev/dl/go{version}.{os}-{cpu}.{ext}",
         os = os_text(platform.os),
@@ -110,7 +111,7 @@ mod tests {
             os: Os::MacOS,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url("1.21.5", platform);
+        let have = super::download_url(&"1.21.5".into(), platform);
         let want = "https://go.dev/dl/go1.21.5.darwin-arm64.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/go.rs
+++ b/src/apps/go.rs
@@ -40,7 +40,7 @@ impl App for Go {
         })
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         let versions = self.installable_versions(1, output)?;
         Ok(versions.into_iter().next().unwrap())
     }
@@ -49,14 +49,15 @@ impl App for Go {
         yard.load_app(self.name(), version, &self.executable_path(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         let tags = github_tags::all(ORG, REPO, 100, output)?;
         let mut go_tags: Vec<String> = tags.into_iter().filter(|tag| tag.starts_with("go")).filter(|tag| !tag.contains("rc")).collect();
         go_tags.sort_unstable_by(|a, b| human_sort::compare(b, a));
         if go_tags.len() > amount {
             go_tags.resize(amount, S(""));
         }
-        Ok(go_tags)
+        let versions: Vec<Version> = go_tags.into_iter().map(|tag| Version::from(tag)).collect();
+        Ok(versions)
     }
 }
 

--- a/src/apps/go.rs
+++ b/src/apps/go.rs
@@ -103,6 +103,7 @@ fn ext_text(os: Os) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::Version;
     use crate::platform::{Cpu, Os, Platform};
 
     #[test]
@@ -111,7 +112,7 @@ mod tests {
             os: Os::MacOS,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url(&"1.21.5".into(), platform);
+        let have = super::download_url(&Version::from("1.21.5"), platform);
         let want = "https://go.dev/dl/go1.21.5.darwin-arm64.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/go.rs
+++ b/src/apps/go.rs
@@ -56,8 +56,7 @@ impl App for Go {
         if go_tags.len() > amount {
             go_tags.resize(amount, S(""));
         }
-        let versions: Vec<Version> = go_tags.into_iter().map(|tag| Version::from(tag)).collect();
-        Ok(versions)
+        Ok(go_tags.into_iter().map(Version::from).collect())
     }
 }
 

--- a/src/apps/goda.rs
+++ b/src/apps/goda.rs
@@ -38,7 +38,7 @@ impl App for Goda {
         })
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         github_releases::latest(ORG, REPO, output)
     }
 
@@ -46,7 +46,7 @@ impl App for Goda {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         github_releases::versions(ORG, REPO, amount, output)
     }
 }

--- a/src/apps/goda.rs
+++ b/src/apps/goda.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_releases;
 use crate::install::compile_go::{compile_go, CompileArgs};
 use crate::platform::{Os, Platform};
@@ -28,7 +29,7 @@ impl App for Goda {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}@v{version}"),
             target_folder: &yard.app_folder(self.name(), version),
@@ -41,7 +42,7 @@ impl App for Goda {
         github_releases::latest(ORG, REPO, output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 

--- a/src/apps/gofmt.rs
+++ b/src/apps/gofmt.rs
@@ -31,7 +31,7 @@ impl App for Gofmt {
         Ok(Some(Executable(executable_path)))
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         (Go {}).latest_installable_version(output)
     }
 
@@ -39,7 +39,7 @@ impl App for Gofmt {
         yard.load_app((Go {}).name(), version, &self.executable_path(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         (Go {}).installable_versions(amount, output)
     }
 }

--- a/src/apps/gofmt.rs
+++ b/src/apps/gofmt.rs
@@ -1,5 +1,6 @@
 use super::go::Go;
 use super::App;
+use crate::config::Version;
 use crate::platform::{Os, Platform};
 use crate::subshell::Executable;
 use crate::yard::Yard;
@@ -23,7 +24,7 @@ impl App for Gofmt {
         "https://go.dev"
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let go = Go {};
         go.install(version, platform, yard, output)?;
         let executable_path = yard.app_folder(go.name(), version).join(self.executable_filename(platform));
@@ -34,7 +35,7 @@ impl App for Gofmt {
         (Go {}).latest_installable_version(output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app((Go {}).name(), version, &self.executable_path(platform))
     }
 

--- a/src/apps/gofumpt.rs
+++ b/src/apps/gofumpt.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_releases;
 use crate::install::compile_go::{compile_go, CompileArgs};
 use crate::install::executable::{self, InstallArgs};
@@ -33,7 +34,7 @@ impl App for Gofumpt {
         github_releases::latest(ORG, REPO, output)
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let result = executable::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
@@ -51,7 +52,7 @@ impl App for Gofumpt {
         })
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
@@ -60,7 +61,7 @@ impl App for Gofumpt {
     }
 }
 
-fn download_url(version: &str, platform: Platform) -> String {
+fn download_url(version: &Version, platform: Platform) -> String {
     format!(
         "https://github.com/{ORG}/{REPO}/releases/download/v{version}/gofumpt_v{version}_{os}_{cpu}{ext}",
         os = os_text(platform.os),
@@ -102,7 +103,7 @@ mod tests {
                 os: Os::MacOS,
                 cpu: Cpu::Arm64,
             };
-            let have = super::super::download_url("0.5.0", platform);
+            let have = super::super::download_url(&"0.5.0".into(), platform);
             let want = "https://github.com/mvdan/gofumpt/releases/download/v0.5.0/gofumpt_v0.5.0_darwin_arm64";
             assert_eq!(have, want);
         }
@@ -113,7 +114,7 @@ mod tests {
                 os: Os::Windows,
                 cpu: Cpu::Intel64,
             };
-            let have = super::super::download_url("0.5.0", platform);
+            let have = super::super::download_url(&"0.5.0".into(), platform);
             let want = "https://github.com/mvdan/gofumpt/releases/download/v0.5.0/gofumpt_v0.5.0_windows_amd64.exe";
             assert_eq!(have, want);
         }

--- a/src/apps/gofumpt.rs
+++ b/src/apps/gofumpt.rs
@@ -30,7 +30,7 @@ impl App for Gofumpt {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         github_releases::latest(ORG, REPO, output)
     }
 
@@ -56,7 +56,7 @@ impl App for Gofumpt {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         github_releases::versions(ORG, REPO, amount, output)
     }
 }

--- a/src/apps/gofumpt.rs
+++ b/src/apps/gofumpt.rs
@@ -95,6 +95,7 @@ fn ext_text(os: Os) -> &'static str {
 #[cfg(test)]
 mod tests {
     mod download_url {
+        use crate::config::Version;
         use crate::platform::{Cpu, Os, Platform};
 
         #[test]
@@ -103,7 +104,7 @@ mod tests {
                 os: Os::MacOS,
                 cpu: Cpu::Arm64,
             };
-            let have = super::super::download_url(&"0.5.0".into(), platform);
+            let have = super::super::download_url(&Version::from("0.5.0"), platform);
             let want = "https://github.com/mvdan/gofumpt/releases/download/v0.5.0/gofumpt_v0.5.0_darwin_arm64";
             assert_eq!(have, want);
         }
@@ -114,7 +115,7 @@ mod tests {
                 os: Os::Windows,
                 cpu: Cpu::Intel64,
             };
-            let have = super::super::download_url(&"0.5.0".into(), platform);
+            let have = super::super::download_url(&Version::from("0.5.0"), platform);
             let want = "https://github.com/mvdan/gofumpt/releases/download/v0.5.0/gofumpt_v0.5.0_windows_amd64.exe";
             assert_eq!(have, want);
         }

--- a/src/apps/golangci_lint.rs
+++ b/src/apps/golangci_lint.rs
@@ -40,7 +40,7 @@ impl App for GolangCiLint {
         // install from source not recommended, see https://golangci-lint.run/usage/install/#install-from-source
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         github_releases::latest(ORG, REPO, output)
     }
 
@@ -48,7 +48,7 @@ impl App for GolangCiLint {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         github_releases::versions(ORG, REPO, amount, output)
     }
 }

--- a/src/apps/golangci_lint.rs
+++ b/src/apps/golangci_lint.rs
@@ -94,6 +94,7 @@ fn ext_text(os: Os) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::Version;
     use crate::platform::{Cpu, Os, Platform};
 
     #[test]
@@ -102,7 +103,7 @@ mod tests {
             os: Os::MacOS,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url(&"1.55.2".into(), platform);
+        let have = super::download_url(&Version::from("1.55.2"), platform);
         let want = "https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-darwin-arm64.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/golangci_lint.rs
+++ b/src/apps/golangci_lint.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_releases;
 use crate::install::packaged_executable::{self, InstallArgs};
 use crate::platform::{Cpu, Os, Platform};
@@ -28,7 +29,7 @@ impl App for GolangCiLint {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         packaged_executable::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
@@ -43,7 +44,7 @@ impl App for GolangCiLint {
         github_releases::latest(ORG, REPO, output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
@@ -52,7 +53,7 @@ impl App for GolangCiLint {
     }
 }
 
-fn download_url(version: &str, platform: Platform) -> String {
+fn download_url(version: &Version, platform: Platform) -> String {
     format!(
         "https://github.com/{ORG}/{REPO}/releases/download/v{version}/golangci-lint-{version}-{os}-{cpu}.{ext}",
         os = os_text(platform.os),
@@ -61,7 +62,7 @@ fn download_url(version: &str, platform: Platform) -> String {
     )
 }
 
-fn executable_path(version: &str, platform: Platform, filename: &str) -> String {
+fn executable_path(version: &Version, platform: Platform, filename: &str) -> String {
     format!(
         "golangci-lint-{version}-{os}-{cpu}/{filename}",
         os = os_text(platform.os),
@@ -101,7 +102,7 @@ mod tests {
             os: Os::MacOS,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url("1.55.2", platform);
+        let have = super::download_url(&"1.55.2".into(), platform);
         let want = "https://github.com/golangci/golangci-lint/releases/download/v1.55.2/golangci-lint-1.55.2-darwin-arm64.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/goreleaser.rs
+++ b/src/apps/goreleaser.rs
@@ -94,6 +94,7 @@ fn ext_text(os: Os) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::Version;
     use crate::platform::{Cpu, Os, Platform};
 
     #[test]
@@ -102,7 +103,7 @@ mod tests {
             os: Os::MacOS,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url(&"1.22.1".into(), platform);
+        let have = super::download_url(&Version::from("1.22.1"), platform);
         let want = "https://github.com/goreleaser/goreleaser/releases/download/v1.22.1/goreleaser_Darwin_arm64.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/goreleaser.rs
+++ b/src/apps/goreleaser.rs
@@ -48,7 +48,7 @@ impl App for Goreleaser {
         })
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         github_releases::latest(ORG, REPO, output)
     }
 
@@ -56,7 +56,7 @@ impl App for Goreleaser {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         github_releases::versions(ORG, REPO, amount, output)
     }
 }

--- a/src/apps/goreleaser.rs
+++ b/src/apps/goreleaser.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_releases;
 use crate::install::compile_go::{compile_go, CompileArgs};
 use crate::install::packaged_executable::{self, InstallArgs};
@@ -28,7 +29,7 @@ impl App for Goreleaser {
         "https://goreleaser.com"
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let result = packaged_executable::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
@@ -51,7 +52,7 @@ impl App for Goreleaser {
         github_releases::latest(ORG, REPO, output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
@@ -60,7 +61,7 @@ impl App for Goreleaser {
     }
 }
 
-fn download_url(version: &str, platform: Platform) -> String {
+fn download_url(version: &Version, platform: Platform) -> String {
     format!(
         "https://github.com/{ORG}/{REPO}/releases/download/v{version}/goreleaser_{os}_{cpu}.{ext}",
         os = os_text(platform.os),
@@ -101,7 +102,7 @@ mod tests {
             os: Os::MacOS,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url("1.22.1", platform);
+        let have = super::download_url(&"1.22.1".into(), platform);
         let want = "https://github.com/goreleaser/goreleaser/releases/download/v1.22.1/goreleaser_Darwin_arm64.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/mdbook.rs
+++ b/src/apps/mdbook.rs
@@ -49,7 +49,7 @@ impl App for MdBook {
         })
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         github_releases::latest(ORG, REPO, output)
     }
 
@@ -57,7 +57,7 @@ impl App for MdBook {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         github_releases::versions(ORG, REPO, amount, output)
     }
 }

--- a/src/apps/mdbook.rs
+++ b/src/apps/mdbook.rs
@@ -87,6 +87,7 @@ fn cpu_text(cpu: Cpu) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::Version;
     use crate::platform::{Cpu, Os, Platform};
 
     #[test]
@@ -95,7 +96,7 @@ mod tests {
             os: Os::Linux,
             cpu: Cpu::Intel64,
         };
-        let have = super::download_url(&"0.4.37".into(), platform);
+        let have = super::download_url(&Version::from("0.4.37"), platform);
         let want = "https://github.com/rust-lang/mdBook/releases/download/v0.4.37/mdbook-v0.4.37-x86_64-unknown-linux-gnu.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/mdbook.rs
+++ b/src/apps/mdbook.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_releases;
 use crate::install::compile_rust::{compile_rust, CompileArgs};
 use crate::install::packaged_executable::{self, InstallArgs};
@@ -29,7 +30,7 @@ impl App for MdBook {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let result = packaged_executable::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
@@ -52,7 +53,7 @@ impl App for MdBook {
         github_releases::latest(ORG, REPO, output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
@@ -61,7 +62,7 @@ impl App for MdBook {
     }
 }
 
-fn download_url(version: &str, platform: Platform) -> String {
+fn download_url(version: &Version, platform: Platform) -> String {
     format!(
         "https://github.com/{ORG}/{REPO}/releases/download/v{version}/mdbook-v{version}-{cpu}-{os}.tar.gz",
         os = os_text(platform.os),
@@ -94,7 +95,7 @@ mod tests {
             os: Os::Linux,
             cpu: Cpu::Intel64,
         };
-        let have = super::download_url("0.4.37", platform);
+        let have = super::download_url(&"0.4.37".into(), platform);
         let want = "https://github.com/rust-lang/mdBook/releases/download/v0.4.37/mdbook-v0.4.37-x86_64-unknown-linux-gnu.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/mod.rs
+++ b/src/apps/mod.rs
@@ -21,6 +21,7 @@ mod scc;
 mod shellcheck;
 mod shfmt;
 
+use crate::config::Version;
 use crate::error::UserError;
 use crate::platform::Platform;
 use crate::subshell::Executable;
@@ -39,10 +40,10 @@ pub trait App {
     fn homepage(&self) -> &'static str;
 
     /// installs this app at the given version into the given yard
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>>;
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>>;
 
     // loads this app from the given yard if it is already installed
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable>;
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable>;
 
     /// provides the versions of this application that can be installed
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>>;

--- a/src/apps/mod.rs
+++ b/src/apps/mod.rs
@@ -46,10 +46,10 @@ pub trait App {
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable>;
 
     /// provides the versions of this application that can be installed
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>>;
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>>;
 
     /// provides the latest version of this application
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String>;
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version>;
 }
 
 pub fn all() -> Apps {

--- a/src/apps/nodejs.rs
+++ b/src/apps/nodejs.rs
@@ -39,7 +39,7 @@ impl App for NodeJS {
         })
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         github_releases::latest(ORG, REPO, output)
     }
 
@@ -47,7 +47,7 @@ impl App for NodeJS {
         yard.load_app(self.name(), version, executable_path(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         github_releases::versions(ORG, REPO, amount, output)
     }
 }

--- a/src/apps/nodejs.rs
+++ b/src/apps/nodejs.rs
@@ -93,6 +93,7 @@ fn ext_text(os: Os) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::Version;
     use crate::platform::{Cpu, Os, Platform};
 
     #[test]
@@ -101,7 +102,7 @@ mod tests {
             os: Os::MacOS,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url(&"20.10.0".into(), platform);
+        let have = super::download_url(&Version::from("20.10.0"), platform);
         let want = "https://nodejs.org/dist/v20.10.0/node-v20.10.0-darwin-arm64.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/nodejs.rs
+++ b/src/apps/nodejs.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_releases;
 use crate::install::archive::{self, InstallArgs};
 use crate::platform::{Cpu, Os, Platform};
@@ -27,7 +28,7 @@ impl App for NodeJS {
         "https://nodejs.org"
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         archive::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
@@ -42,7 +43,7 @@ impl App for NodeJS {
         github_releases::latest(ORG, REPO, output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, executable_path(platform))
     }
 
@@ -51,7 +52,7 @@ impl App for NodeJS {
     }
 }
 
-pub fn download_url(version: &str, platform: Platform) -> String {
+pub fn download_url(version: &Version, platform: Platform) -> String {
     format!(
         "https://nodejs.org/dist/v{version}/node-v{version}-{os}-{cpu}.{ext}",
         os = os_text(platform.os),
@@ -100,7 +101,7 @@ mod tests {
             os: Os::MacOS,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url("20.10.0", platform);
+        let have = super::download_url(&"20.10.0".into(), platform);
         let want = "https://nodejs.org/dist/v20.10.0/node-v20.10.0-darwin-arm64.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/npm.rs
+++ b/src/apps/npm.rs
@@ -31,7 +31,7 @@ impl App for Npm {
         Ok(Some(Executable(executable_path)))
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         (NodeJS {}).latest_installable_version(output)
     }
 
@@ -39,7 +39,7 @@ impl App for Npm {
         yard.load_app((NodeJS {}).name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         (NodeJS {}).installable_versions(amount, output)
     }
 }

--- a/src/apps/npm.rs
+++ b/src/apps/npm.rs
@@ -1,5 +1,6 @@
 use super::nodejs::NodeJS;
 use super::App;
+use crate::config::Version;
 use crate::platform::{Os, Platform};
 use crate::subshell::Executable;
 use crate::yard::Yard;
@@ -23,7 +24,7 @@ impl App for Npm {
         "https://www.npmjs.com"
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let nodejs = NodeJS {};
         nodejs.install(version, platform, yard, output)?;
         let executable_path = yard.app_folder(nodejs.name(), version).join(self.executable_filename(platform));
@@ -34,7 +35,7 @@ impl App for Npm {
         (NodeJS {}).latest_installable_version(output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app((NodeJS {}).name(), version, self.executable_filename(platform))
     }
 

--- a/src/apps/npx.rs
+++ b/src/apps/npx.rs
@@ -1,5 +1,6 @@
 use super::nodejs::NodeJS;
 use super::App;
+use crate::config::Version;
 use crate::platform::{Os, Platform};
 use crate::subshell::Executable;
 use crate::yard::Yard;
@@ -23,7 +24,7 @@ impl App for Npx {
         "https://www.npmjs.com"
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let nodejs = NodeJS {};
         nodejs.install(version, platform, yard, output)?;
         let executable_path = yard.app_folder(nodejs.name(), version).join(self.executable_filename(platform));
@@ -34,7 +35,7 @@ impl App for Npx {
         (NodeJS {}).latest_installable_version(output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app((NodeJS {}).name(), version, self.executable_filename(platform))
     }
 

--- a/src/apps/npx.rs
+++ b/src/apps/npx.rs
@@ -31,7 +31,7 @@ impl App for Npx {
         Ok(Some(Executable(executable_path)))
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         (NodeJS {}).latest_installable_version(output)
     }
 
@@ -39,7 +39,7 @@ impl App for Npx {
         yard.load_app((NodeJS {}).name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         (NodeJS {}).installable_versions(amount, output)
     }
 }

--- a/src/apps/scc.rs
+++ b/src/apps/scc.rs
@@ -49,7 +49,7 @@ impl App for Scc {
         })
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         github_releases::latest(ORG, REPO, output)
     }
 
@@ -57,7 +57,7 @@ impl App for Scc {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         github_releases::versions(ORG, REPO, amount, output)
     }
 }

--- a/src/apps/scc.rs
+++ b/src/apps/scc.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_releases;
 use crate::install::compile_go::{compile_go, CompileArgs};
 use crate::install::packaged_executable::{self, InstallArgs};
@@ -29,7 +30,7 @@ impl App for Scc {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let result = packaged_executable::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
@@ -52,7 +53,7 @@ impl App for Scc {
         github_releases::latest(ORG, REPO, output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
@@ -61,7 +62,7 @@ impl App for Scc {
     }
 }
 
-fn download_url(version: &str, platform: Platform) -> String {
+fn download_url(version: &Version, platform: Platform) -> String {
     format!(
         "https://github.com/{ORG}/{REPO}/releases/download/v{version}/scc_{version}_{os}_{cpu}.{ext}",
         os = os_text(platform.os),
@@ -99,7 +100,7 @@ mod tests {
             os: Os::MacOS,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url("3.1.0", platform);
+        let have = super::download_url(&"3.1.0".into(), platform);
         let want = "https://github.com/boyter/scc/releases/download/v3.1.0/scc_3.1.0_Darwin_arm64.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/scc.rs
+++ b/src/apps/scc.rs
@@ -92,6 +92,7 @@ fn ext_text(_os: Os) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::Version;
     use crate::platform::{Cpu, Os, Platform};
 
     #[test]
@@ -100,7 +101,7 @@ mod tests {
             os: Os::MacOS,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url(&"3.1.0".into(), platform);
+        let have = super::download_url(&Version::from("3.1.0"), platform);
         let want = "https://github.com/boyter/scc/releases/download/v3.1.0/scc_3.1.0_Darwin_arm64.tar.gz";
         assert_eq!(have, want);
     }

--- a/src/apps/shellcheck.rs
+++ b/src/apps/shellcheck.rs
@@ -84,6 +84,7 @@ fn ext_text(os: Os) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::Version;
     use crate::platform::{Cpu, Os, Platform};
 
     #[test]
@@ -92,7 +93,7 @@ mod tests {
             os: Os::Linux,
             cpu: Cpu::Intel64,
         };
-        let have = super::download_url(&"0.9.0".into(), platform);
+        let have = super::download_url(&Version::from("0.9.0"), platform);
         let want = "https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.linux.x86_64.tar.xz";
         assert_eq!(have, want);
     }

--- a/src/apps/shellcheck.rs
+++ b/src/apps/shellcheck.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_releases;
 use crate::install::packaged_executable::{self, InstallArgs};
 use crate::platform::{Cpu, Os, Platform};
@@ -27,7 +28,7 @@ impl App for ShellCheck {
         "https://www.shellcheck.net"
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         packaged_executable::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
@@ -41,7 +42,7 @@ impl App for ShellCheck {
         github_releases::latest(ORG, REPO, output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
@@ -50,7 +51,7 @@ impl App for ShellCheck {
     }
 }
 
-fn download_url(version: &str, platform: Platform) -> String {
+fn download_url(version: &Version, platform: Platform) -> String {
     format!(
         "https://github.com/{ORG}/{REPO}/releases/download/v{version}/shellcheck-v{version}.{os}.{cpu}.{ext}",
         os = os_text(platform.os),
@@ -91,7 +92,7 @@ mod tests {
             os: Os::Linux,
             cpu: Cpu::Intel64,
         };
-        let have = super::download_url("0.9.0", platform);
+        let have = super::download_url(&"0.9.0".into(), platform);
         let want = "https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.linux.x86_64.tar.xz";
         assert_eq!(have, want);
     }

--- a/src/apps/shellcheck.rs
+++ b/src/apps/shellcheck.rs
@@ -38,7 +38,7 @@ impl App for ShellCheck {
         })
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         github_releases::latest(ORG, REPO, output)
     }
 
@@ -46,7 +46,7 @@ impl App for ShellCheck {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         github_releases::versions(ORG, REPO, amount, output)
     }
 }

--- a/src/apps/shfmt.rs
+++ b/src/apps/shfmt.rs
@@ -1,4 +1,5 @@
 use super::App;
+use crate::config::Version;
 use crate::hosting::github_releases;
 use crate::install::compile_go::{compile_go, CompileArgs};
 use crate::install::executable::{self, InstallArgs};
@@ -29,7 +30,7 @@ impl App for Shfmt {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
 
-    fn install(&self, version: &str, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
+    fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let result = executable::install(InstallArgs {
             app_name: self.name(),
             artifact_url: download_url(version, platform),
@@ -51,7 +52,7 @@ impl App for Shfmt {
         github_releases::latest(ORG, REPO, output)
     }
 
-    fn load(&self, version: &str, platform: Platform, yard: &Yard) -> Option<Executable> {
+    fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
@@ -60,7 +61,7 @@ impl App for Shfmt {
     }
 }
 
-fn download_url(version: &str, platform: Platform) -> String {
+fn download_url(version: &Version, platform: Platform) -> String {
     format!(
         "https://github.com/{ORG}/{REPO}/releases/download/v{version}/shfmt_v{version}_{os}_{cpu}{ext}",
         os = os_text(platform.os),
@@ -101,7 +102,7 @@ mod tests {
             os: Os::MacOS,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url("3.7.0", platform);
+        let have = super::download_url(&"3.7.0".into(), platform);
         let want = "https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_darwin_arm64";
         assert_eq!(have, want);
     }

--- a/src/apps/shfmt.rs
+++ b/src/apps/shfmt.rs
@@ -94,6 +94,7 @@ fn ext_text(os: Os) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::Version;
     use crate::platform::{Cpu, Os, Platform};
 
     #[test]
@@ -102,7 +103,7 @@ mod tests {
             os: Os::MacOS,
             cpu: Cpu::Arm64,
         };
-        let have = super::download_url(&"3.7.0".into(), platform);
+        let have = super::download_url(&Version::from("3.7.0"), platform);
         let want = "https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_darwin_arm64";
         assert_eq!(have, want);
     }

--- a/src/apps/shfmt.rs
+++ b/src/apps/shfmt.rs
@@ -48,7 +48,7 @@ impl App for Shfmt {
         })
     }
 
-    fn latest_installable_version(&self, output: &dyn Output) -> Result<String> {
+    fn latest_installable_version(&self, output: &dyn Output) -> Result<Version> {
         github_releases::latest(ORG, REPO, output)
     }
 
@@ -56,7 +56,7 @@ impl App for Shfmt {
         yard.load_app(self.name(), version, self.executable_filename(platform))
     }
 
-    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<String>> {
+    fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         github_releases::versions(ORG, REPO, amount, output)
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -163,7 +163,7 @@ mod tests {
             mod available {
                 use super::super::parse_args;
                 use crate::cli::{Args, Command};
-                use crate::config::AppVersion;
+                use crate::config::{AppVersion, Version};
                 use crate::error::UserError;
                 use big_s::S;
 
@@ -174,7 +174,7 @@ mod tests {
                         command: Command::Available {
                             app: AppVersion {
                                 name: S("shellcheck"),
-                                version: S(""),
+                                version: Version::None,
                             },
                             include_path: false,
                             log: None,
@@ -190,7 +190,7 @@ mod tests {
                         command: Command::Available {
                             app: AppVersion {
                                 name: S("shellcheck"),
-                                version: S(""),
+                                version: Version::None,
                             },
                             include_path: true,
                             log: Some(S("detect")),
@@ -211,7 +211,7 @@ mod tests {
                 use super::super::parse_args;
                 use crate::cli::{Args, Command};
                 use crate::cmd::run;
-                use crate::config::AppVersion;
+                use crate::config::{AppVersion, Version};
                 use crate::error::UserError;
                 use big_s::S;
 
@@ -223,7 +223,7 @@ mod tests {
                             data: run::Data {
                                 app_version: AppVersion {
                                     name: S("app"),
-                                    version: S(""),
+                                    version: Version::None,
                                 },
                                 app_args: vec![],
                                 error_on_output: true,
@@ -279,7 +279,7 @@ mod tests {
                             data: run::Data {
                                 app_version: AppVersion {
                                     name: S("app"),
-                                    version: S("2"),
+                                    version: "2".into(),
                                 },
                                 app_args: vec![S("arg1")],
                                 error_on_output: false,
@@ -316,7 +316,7 @@ mod tests {
                             data: run::Data {
                                 app_version: AppVersion {
                                     name: S("app"),
-                                    version: S("2"),
+                                    version: "2".into(),
                                 },
                                 app_args: vec![],
                                 error_on_output: false,
@@ -337,7 +337,7 @@ mod tests {
                             data: run::Data {
                                 app_version: AppVersion {
                                     name: S("app"),
-                                    version: S("2"),
+                                    version: "2".into(),
                                 },
                                 app_args: vec![],
                                 error_on_output: false,
@@ -373,7 +373,7 @@ mod tests {
                         data: run::Data {
                             app_version: AppVersion {
                                 name: S("app"),
-                                version: S("2"),
+                                version: "2".into(),
                             },
                             app_args: vec![S("arg1")],
                             error_on_output: false,
@@ -449,7 +449,7 @@ mod tests {
             mod which {
                 use super::super::parse_args;
                 use crate::cli::{Args, Command};
-                use crate::config::AppVersion;
+                use crate::config::{AppVersion, Version};
                 use crate::UserError;
                 use big_s::S;
 
@@ -460,7 +460,7 @@ mod tests {
                         command: Command::Which {
                             app: AppVersion {
                                 name: S("shellcheck"),
-                                version: S(""),
+                                version: Version::None,
                             },
                             include_path: false,
                             log: None,
@@ -476,7 +476,7 @@ mod tests {
                         command: Command::Which {
                             app: AppVersion {
                                 name: S("shellcheck"),
-                                version: S(""),
+                                version: Version::None,
                             },
                             include_path: true,
                             log: Some(S("detect")),
@@ -498,7 +498,7 @@ mod tests {
             use super::parse_args;
             use crate::cli::{args, Command};
             use crate::cmd::run;
-            use crate::config::AppVersion;
+            use crate::config::{AppVersion, Version};
             use args::Args;
             use big_s::S;
 
@@ -510,7 +510,7 @@ mod tests {
                         data: run::Data {
                             app_version: AppVersion {
                                 name: S("app"),
-                                version: S("2"),
+                                version: Version::None,
                             },
                             app_args: vec![],
                             error_on_output: false,
@@ -531,7 +531,7 @@ mod tests {
                         data: run::Data {
                             app_version: AppVersion {
                                 name: S("app"),
-                                version: S("2"),
+                                version: "2".into(),
                             },
                             app_args: vec![S("--arg1"), S("arg2")],
                             error_on_output: false,
@@ -557,7 +557,7 @@ mod tests {
                 let have = parse_args(vec!["rta", "--log=l1", "app@2", "--arg1", "arg2"]);
                 let app = AppVersion {
                     name: S("app"),
-                    version: S("2"),
+                    version: "2".into(),
                 };
                 let want = Ok(Args {
                     command: Command::RunApp {
@@ -582,7 +582,7 @@ mod tests {
                         data: run::Data {
                             app_version: AppVersion {
                                 name: S("app"),
-                                version: S("2"),
+                                version: "2".into(),
                             },
                             app_args: vec![S("--log=app"), S("--version")],
                             error_on_output: false,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -498,7 +498,7 @@ mod tests {
             use super::parse_args;
             use crate::cli::{args, Command};
             use crate::cmd::run;
-            use crate::config::{AppVersion, Version} ;
+            use crate::config::{AppVersion, Version};
             use args::Args;
             use big_s::S;
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -498,7 +498,7 @@ mod tests {
             use super::parse_args;
             use crate::cli::{args, Command};
             use crate::cmd::run;
-            use crate::config::{AppVersion, Version};
+            use crate::config::AppVersion ;
             use args::Args;
             use big_s::S;
 
@@ -510,7 +510,7 @@ mod tests {
                         data: run::Data {
                             app_version: AppVersion {
                                 name: S("app"),
-                                version: Version::None,
+                                version: "2".into(),
                             },
                             app_args: vec![],
                             error_on_output: false,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -157,7 +157,7 @@ mod tests {
             use super::parse_args;
             use crate::cli::{Args, Command};
             use crate::cmd::run;
-            use crate::config::AppVersion;
+            use crate::config::{AppVersion, Version};
             use crate::error::UserError;
 
             mod available {
@@ -267,7 +267,7 @@ mod tests {
                 use super::super::parse_args;
                 use crate::cli::{Args, Command};
                 use crate::cmd::run;
-                use crate::config::AppVersion;
+                use crate::config::{AppVersion, Version};
                 use crate::UserError;
                 use big_s::S;
 
@@ -279,7 +279,7 @@ mod tests {
                             data: run::Data {
                                 app_version: AppVersion {
                                     name: S("app"),
-                                    version: "2".into(),
+                                    version: Version::from("2"),
                                 },
                                 app_args: vec![S("arg1")],
                                 error_on_output: false,
@@ -304,7 +304,7 @@ mod tests {
                 use super::super::parse_args;
                 use crate::cli::{Args, Command};
                 use crate::cmd::run;
-                use crate::config::AppVersion;
+                use crate::config::{AppVersion, Version};
                 use crate::error::UserError;
                 use big_s::S;
 
@@ -316,7 +316,7 @@ mod tests {
                             data: run::Data {
                                 app_version: AppVersion {
                                     name: S("app"),
-                                    version: "2".into(),
+                                    version: Version::from("2"),
                                 },
                                 app_args: vec![],
                                 error_on_output: false,
@@ -337,7 +337,7 @@ mod tests {
                             data: run::Data {
                                 app_version: AppVersion {
                                     name: S("app"),
-                                    version: "2".into(),
+                                    version: Version::from("2"),
                                 },
                                 app_args: vec![],
                                 error_on_output: false,
@@ -373,7 +373,7 @@ mod tests {
                         data: run::Data {
                             app_version: AppVersion {
                                 name: S("app"),
-                                version: "2".into(),
+                                version: Version::from("2"),
                             },
                             app_args: vec![S("arg1")],
                             error_on_output: false,
@@ -498,7 +498,7 @@ mod tests {
             use super::parse_args;
             use crate::cli::{args, Command};
             use crate::cmd::run;
-            use crate::config::AppVersion ;
+            use crate::config::{AppVersion, Version} ;
             use args::Args;
             use big_s::S;
 
@@ -510,7 +510,7 @@ mod tests {
                         data: run::Data {
                             app_version: AppVersion {
                                 name: S("app"),
-                                version: "2".into(),
+                                version: Version::from("2"),
                             },
                             app_args: vec![],
                             error_on_output: false,
@@ -531,7 +531,7 @@ mod tests {
                         data: run::Data {
                             app_version: AppVersion {
                                 name: S("app"),
-                                version: "2".into(),
+                                version: Version::from("2"),
                             },
                             app_args: vec![S("--arg1"), S("arg2")],
                             error_on_output: false,
@@ -549,7 +549,7 @@ mod tests {
             use super::parse_args;
             use crate::cli::{Args, Command};
             use crate::cmd::run;
-            use crate::config::AppVersion;
+            use crate::config::{AppVersion, Version};
             use big_s::S;
 
             #[test]
@@ -557,7 +557,7 @@ mod tests {
                 let have = parse_args(vec!["rta", "--log=l1", "app@2", "--arg1", "arg2"]);
                 let app = AppVersion {
                     name: S("app"),
-                    version: "2".into(),
+                    version: Version::from("2"),
                 };
                 let want = Ok(Args {
                     command: Command::RunApp {
@@ -582,7 +582,7 @@ mod tests {
                         data: run::Data {
                             app_version: AppVersion {
                                 name: S("app"),
-                                version: "2".into(),
+                                version: Version::from("2"),
                             },
                             app_args: vec![S("--log=app"), S("--version")],
                             error_on_output: false,

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -45,7 +45,7 @@ pub struct Data {
 }
 
 pub fn load_or_install(mut app_version: AppVersion, include_path: bool, output: &dyn Output) -> Result<Option<Executable>> {
-    if app_version.version.is_empty() {
+    if app_version.version.is_none() {
         let config = config::load()?;
         let Some(configured_app) = config.lookup(&app_version.name) else {
             return Err(UserError::RunRequestMissingVersion);

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -1,6 +1,6 @@
 use crate::apps;
-use crate::config::AppVersion;
 use crate::config;
+use crate::config::AppVersion;
 use crate::error::UserError;
 use crate::filesystem::find_global_install;
 use crate::platform;

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -20,7 +20,7 @@ pub fn update(output: &dyn Output) -> Result<ExitCode> {
         }
         new_config.apps.push(AppVersion {
             name: old_app.name.to_string(),
-            version: latest.into(),
+            version: latest,
         });
     }
     config::save(&new_config)?;

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -13,14 +13,14 @@ pub fn update(output: &dyn Output) -> Result<ExitCode> {
         let app = all_apps.lookup(&old_app.name)?;
         output.print(&format!("updating {} ... ", old_app.name));
         let latest = app.latest_installable_version(output)?;
-        if latest == old_app.version {
+        if old_app.version == latest {
             output.println(&format!("{}", "current".green()));
         } else {
-            output.println(&format!("{} -> {}", old_app.version.cyan(), latest.cyan()));
+            output.println(&format!("{} -> {}", old_app.version.as_str().cyan(), latest.as_str().cyan()));
         }
         new_config.apps.push(AppVersion {
             name: old_app.name.to_string(),
-            version: latest,
+            version: latest.into(),
         });
     }
     config::save(&new_config)?;

--- a/src/config/app_version.rs
+++ b/src/config/app_version.rs
@@ -4,7 +4,7 @@ use super::Version;
 #[derive(Debug, PartialEq)]
 pub struct AppVersion {
     pub name: String,
-    pub version: Option<String>,
+    pub version: Version,
 }
 
 impl AppVersion {
@@ -40,7 +40,7 @@ mod tests {
             let have = AppVersion::new(give);
             let want = AppVersion {
                 name: S("shellcheck"),
-                version: Version::none(),
+                version: Version::None,
             };
             pretty::assert_eq!(have, want);
         }
@@ -51,7 +51,7 @@ mod tests {
             let have = AppVersion::new(give);
             let want = AppVersion {
                 name: S("shellcheck"),
-                version: S(""),
+                version: Version::None,
             };
             pretty::assert_eq!(have, want);
         }

--- a/src/config/app_version.rs
+++ b/src/config/app_version.rs
@@ -1,8 +1,10 @@
+use super::Version;
+
 /// a request from the user to run a particular app
 #[derive(Debug, PartialEq)]
 pub struct AppVersion {
     pub name: String,
-    pub version: String,
+    pub version: Option<String>,
 }
 
 impl AppVersion {
@@ -10,7 +12,7 @@ impl AppVersion {
         let (app_name, version) = token.as_ref().split_once('@').unwrap_or((token.as_ref(), ""));
         AppVersion {
             name: app_name.to_string(),
-            version: version.to_string(),
+            version: version.into(),
         }
     }
 }
@@ -18,7 +20,7 @@ impl AppVersion {
 #[cfg(test)]
 mod tests {
     mod parse {
-        use crate::config::AppVersion;
+        use crate::config::{AppVersion, Version};
         use big_s::S;
 
         #[test]
@@ -27,7 +29,7 @@ mod tests {
             let have = AppVersion::new(give);
             let want = AppVersion {
                 name: S("shellcheck"),
-                version: S("0.9.0"),
+                version: "0.9.0".into(),
             };
             pretty::assert_eq!(have, want);
         }
@@ -38,7 +40,7 @@ mod tests {
             let have = AppVersion::new(give);
             let want = AppVersion {
                 name: S("shellcheck"),
-                version: S(""),
+                version: Version::none(),
             };
             pretty::assert_eq!(have, want);
         }

--- a/src/config/app_version.rs
+++ b/src/config/app_version.rs
@@ -29,7 +29,7 @@ mod tests {
             let have = AppVersion::new(give);
             let want = AppVersion {
                 name: S("shellcheck"),
-                version: "0.9.0".into(),
+                version: Version::from("0.9.0"),
             };
             pretty::assert_eq!(have, want);
         }

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -66,7 +66,7 @@ pub fn parse_line(line_text: &str, line_no: usize) -> Result<Option<AppVersion>>
     }
     Ok(Some(AppVersion {
         name: name.to_string(),
-        version: version.to_string(),
+        version: version.into(),
     }))
 }
 
@@ -115,15 +115,15 @@ mod tests {
                 apps: vec![
                     AppVersion {
                         name: S("alpha"),
-                        version: S("1.2.3"),
+                        version: "1.2.3".into(),
                     },
                     AppVersion {
                         name: S("beta"),
-                        version: S("2.3.4"),
+                        version: "2.3.4".into(),
                     },
                     AppVersion {
                         name: S("gamma"),
-                        version: S("3.4.5"),
+                        version: "3.4.5".into(),
                     },
                 ],
             };
@@ -143,7 +143,7 @@ mod tests {
             let have = parse_line(give, 1).unwrap();
             let want = Some(AppVersion {
                 name: S("shellcheck"),
-                version: S("0.9.0"),
+                version: "0.9.0".into(),
             });
             pretty::assert_eq!(have, want);
         }
@@ -154,7 +154,7 @@ mod tests {
             let have = parse_line(give, 1).unwrap();
             let want = Some(AppVersion {
                 name: S("shellcheck"),
-                version: S("0.9.0"),
+                version: "0.9.0".into(),
             });
             pretty::assert_eq!(have, want);
         }
@@ -165,7 +165,7 @@ mod tests {
             let have = parse_line(give, 1).unwrap();
             let want = Some(AppVersion {
                 name: S("shellcheck"),
-                version: S("0.9.0"),
+                version: "0.9.0".into(),
             });
             pretty::assert_eq!(have, want);
         }
@@ -208,7 +208,7 @@ mod tests {
             let have = parse_line(give, 1).unwrap();
             let want = Some(AppVersion {
                 name: S("shellcheck"),
-                version: S("0.9.0"),
+                version: "0.9.0".into(),
             });
             pretty::assert_eq!(have, want);
         }

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -102,7 +102,7 @@ mod tests {
 
     mod parse {
         use super::super::parse;
-        use crate::config::{AppVersion,Config, Version};
+        use crate::config::{AppVersion, Config, Version};
         use big_s::S;
 
         #[test]

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -102,7 +102,7 @@ mod tests {
 
     mod parse {
         use super::super::parse;
-        use crate::config::{AppVersion,Config};
+        use crate::config::{AppVersion,Config, Version};
         use big_s::S;
 
         #[test]
@@ -115,15 +115,15 @@ mod tests {
                 apps: vec![
                     AppVersion {
                         name: S("alpha"),
-                        version: "1.2.3".into(),
+                        version: Version::from("1.2.3"),
                     },
                     AppVersion {
                         name: S("beta"),
-                        version: "2.3.4".into(),
+                        version: Version::from("2.3.4"),
                     },
                     AppVersion {
                         name: S("gamma"),
-                        version: "3.4.5".into(),
+                        version: Version::from("3.4.5"),
                     },
                 ],
             };
@@ -133,7 +133,7 @@ mod tests {
 
     mod parse_line {
         use super::super::parse_line;
-        use crate::config::AppVersion;
+        use crate::config::{AppVersion, Version};
         use crate::error::UserError;
         use big_s::S;
 
@@ -143,7 +143,7 @@ mod tests {
             let have = parse_line(give, 1).unwrap();
             let want = Some(AppVersion {
                 name: S("shellcheck"),
-                version: "0.9.0".into(),
+                version: Version::from("0.9.0"),
             });
             pretty::assert_eq!(have, want);
         }
@@ -154,7 +154,7 @@ mod tests {
             let have = parse_line(give, 1).unwrap();
             let want = Some(AppVersion {
                 name: S("shellcheck"),
-                version: "0.9.0".into(),
+                version: Version::from("0.9.0"),
             });
             pretty::assert_eq!(have, want);
         }
@@ -165,7 +165,7 @@ mod tests {
             let have = parse_line(give, 1).unwrap();
             let want = Some(AppVersion {
                 name: S("shellcheck"),
-                version: "0.9.0".into(),
+                version: Version::from("0.9.0"),
             });
             pretty::assert_eq!(have, want);
         }
@@ -208,7 +208,7 @@ mod tests {
             let have = parse_line(give, 1).unwrap();
             let want = Some(AppVersion {
                 name: S("shellcheck"),
-                version: "0.9.0".into(),
+                version: Version::from("0.9.0"),
             });
             pretty::assert_eq!(have, want);
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,11 +5,13 @@ mod config;
 mod create;
 mod load;
 mod save;
+mod version;
 
 pub use app_version::AppVersion;
 pub use config::Config;
 pub use create::create;
 pub use load::load;
 pub use save::save;
+pub use version::Version;
 
 pub const FILE_NAME: &str = ".tool-versions";

--- a/src/config/version.rs
+++ b/src/config/version.rs
@@ -16,9 +16,6 @@ impl Version {
         }
     }
 
-    pub(crate) fn is_some(&self) -> bool {
-        matches!(*self, Version::Some(_))
-    }
     pub(crate) fn is_none(&self) -> bool {
         matches!(*self, Version::None)
     }
@@ -43,7 +40,7 @@ impl AsRef<str> for Version {
 impl Display for Version{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Version::Some(text) = self {
-            f.write_str(&text);
+            f.write_str(&text)?;
         }
         Ok(())
     }

--- a/src/config/version.rs
+++ b/src/config/version.rs
@@ -31,7 +31,7 @@ impl AsRef<Path> for Version {
 impl AsRef<str> for Version {
     fn as_ref(&self) -> &str {
         match self {
-            Version::Some(text) => &text,
+            Version::Some(text) => text,
             Version::None => "",
         }
     }
@@ -40,7 +40,7 @@ impl AsRef<str> for Version {
 impl Display for Version{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Version::Some(text) = self {
-            f.write_str(&text)?;
+            f.write_str(text)?;
         }
         Ok(())
     }

--- a/src/config/version.rs
+++ b/src/config/version.rs
@@ -1,18 +1,51 @@
-/// a string that represents
-#[derive(Debug, Default, PartialEq)]
-pub struct Version(Option<String>);
+use std::fmt::Display;
+use std::path::Path;
 
-impl Version{
-    pub fn none() -> Version {
-        Version(None)
+/// a string that represents
+#[derive(Debug, PartialEq)]
+pub enum Version {
+    Some(String),
+    None,
+}
+impl Version {
+    pub(crate) fn is_some(&self) -> bool {
+        matches!(*self, Version::Some(_))
+    }
+    pub(crate) fn is_none(&self) -> bool {
+        matches!(*self, Version::None)
+    }
+}
+
+impl AsRef<Path> for Version {
+    fn as_ref(&self) -> &Path {
+        let text: &str = self.as_ref();
+        Path::new(text)
+    }
+}
+
+impl AsRef<str> for Version {
+    fn as_ref(&self) -> &str {
+        match self {
+            Version::Some(text) => &text,
+            Version::None => "",
+        }
+    }
+}
+
+impl Display for Version{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Version::Some(text) = self {
+            f.write_str(&text);
+        }
+        Ok(())
     }
 }
 
 impl From<&str> for Version {
     fn from(text: &str) -> Self {
         if text.is_empty() {
-            return Version(None);
+            return Version::None;
         }
-        Version(Some(text.to_string()))
+        Version::Some(text.to_string())
     }
 }

--- a/src/config/version.rs
+++ b/src/config/version.rs
@@ -31,7 +31,7 @@ impl AsRef<Path> for Version {
     }
 }
 
-impl Display for Version{
+impl Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Version::Some(text) = self {
             f.write_str(text)?;

--- a/src/config/version.rs
+++ b/src/config/version.rs
@@ -26,17 +26,8 @@ impl Version {
 
 impl AsRef<Path> for Version {
     fn as_ref(&self) -> &Path {
-        let text: &str = self.as_ref();
+        let text: &str = self.as_str();
         Path::new(text)
-    }
-}
-
-impl AsRef<str> for Version {
-    fn as_ref(&self) -> &str {
-        match self {
-            Version::Some(text) => text,
-            Version::None => "",
-        }
     }
 }
 
@@ -69,14 +60,12 @@ impl From<String> for Version {
 
 impl PartialEq<str> for Version {
     fn eq(&self, other: &str) -> bool {
-        let text: &str = self.as_ref();
-        text == other
+        self.as_str() == other
     }
 }
 
 impl PartialEq<String> for Version {
     fn eq(&self, other: &String) -> bool {
-        let text: &str = self.as_ref();
-        text == *other
+        self.as_str() == *other
     }
 }

--- a/src/config/version.rs
+++ b/src/config/version.rs
@@ -17,7 +17,10 @@ impl Version {
     }
 
     pub(crate) fn is_none(&self) -> bool {
-        matches!(*self, Version::None)
+        match self {
+            Version::None => true,
+            Version::Some(_) => false,
+        }
     }
 }
 

--- a/src/config/version.rs
+++ b/src/config/version.rs
@@ -1,0 +1,18 @@
+/// a string that represents
+#[derive(Debug, Default, PartialEq)]
+pub struct Version(Option<String>);
+
+impl Version{
+    pub fn none() -> Version {
+        Version(None)
+    }
+}
+
+impl From<&str> for Version {
+    fn from(text: &str) -> Self {
+        if text.is_empty() {
+            return Version(None);
+        }
+        Version(Some(text.to_string()))
+    }
+}

--- a/src/config/version.rs
+++ b/src/config/version.rs
@@ -7,7 +7,15 @@ pub enum Version {
     Some(String),
     None,
 }
+
 impl Version {
+    pub(crate) fn as_str(&self) -> &str {
+        match self {
+            Version::Some(text) => text,
+            Version::None => "",
+        }
+    }
+
     pub(crate) fn is_some(&self) -> bool {
         matches!(*self, Version::Some(_))
     }
@@ -47,5 +55,28 @@ impl From<&str> for Version {
             return Version::None;
         }
         Version::Some(text.to_string())
+    }
+}
+
+impl From<String> for Version {
+    fn from(text: String) -> Self {
+        if text.is_empty() {
+            return Version::None;
+        }
+        Version::Some(text)
+    }
+}
+
+impl PartialEq<str> for Version {
+    fn eq(&self, other: &str) -> bool {
+        let text: &str = self.as_ref();
+        text == other
+    }
+}
+
+impl PartialEq<String> for Version {
+    fn eq(&self, other: &String) -> bool {
+        let text: &str = self.as_ref();
+        text == *other
     }
 }

--- a/src/yard/yard.rs
+++ b/src/yard/yard.rs
@@ -67,7 +67,7 @@ mod tests {
     #[test]
     fn app_file_path() {
         let yard = Yard { root: PathBuf::from("/root") };
-        let have = yard.app_folder("shellcheck", &Version::from("0.9.0").into()).join("shellcheck.exe");
+        let have = yard.app_folder("shellcheck", &Version::from("0.9.0")).join("shellcheck.exe");
         let want = PathBuf::from("/root/apps/shellcheck/0.9.0/shellcheck.exe");
         assert_eq!(have, want);
     }
@@ -75,13 +75,14 @@ mod tests {
     #[test]
     fn app_folder() {
         let yard = Yard { root: PathBuf::from("/root") };
-        let have = yard.app_folder("shellcheck", &Version::from("0.9.0").into());
+        let have = yard.app_folder("shellcheck", &Version::from("0.9.0"));
         let want = PathBuf::from("/root/apps/shellcheck/0.9.0");
         assert_eq!(have, want);
     }
 
     mod is_not_installable {
         use crate::config::AppVersion;
+        use crate::config::Version;
         use crate::yard::create;
         use crate::yard::Yard;
         use big_s::S;
@@ -93,7 +94,7 @@ mod tests {
             let yard = create(tempdir.path()).unwrap();
             let app_version = AppVersion {
                 name: S("shellcheck"),
-                version: "0.9.0".into(),
+                version: Version::from("0.9.0"),
             };
             yard.mark_not_installable(&app_version).unwrap();
             let have = yard.is_not_installable(&app_version);
@@ -105,7 +106,7 @@ mod tests {
             let yard = Yard { root: PathBuf::from("/root") };
             let app_version = AppVersion {
                 name: S("shellcheck"),
-                version: "0.9.0".into(),
+                version: Version::from("0.9.0"),
             };
             let have = yard.is_not_installable(&app_version);
             assert!(!have);
@@ -147,7 +148,7 @@ mod tests {
             let yard = Yard { root: PathBuf::from("/root") };
             let app_version = AppVersion {
                 name: S("shellcheck"),
-                version: "0.9.0".into(),
+                version: Version::from("0.9.0"),
             };
             let loaded = yard.load_app(&app_version.name, &app_version.version, "executable");
             assert!(loaded.is_none());
@@ -167,7 +168,7 @@ mod tests {
     #[test]
     fn not_installable_path() {
         let yard = Yard { root: PathBuf::from("/root") };
-        let have = yard.not_installable_path("shellcheck", &Version::from("0.9.0").into());
+        let have = yard.not_installable_path("shellcheck", &Version::from("0.9.0"));
         let want = PathBuf::from("/root/apps/shellcheck/0.9.0/not_installable");
         assert_eq!(have, want);
     }

--- a/src/yard/yard.rs
+++ b/src/yard/yard.rs
@@ -1,4 +1,4 @@
-use crate::config::AppVersion;
+use crate::config::{AppVersion, Version};
 use crate::error::UserError;
 use crate::subshell::Executable;
 use crate::Result;
@@ -12,8 +12,8 @@ pub struct Yard {
 /// stores executables of and metadata about applications
 impl Yard {
     /// provides the path to the folder containing the given application
-    pub fn app_folder(&self, app_name: &str, app_version: &str) -> PathBuf {
-        self.root.join("apps").join(app_name).join(app_version)
+    pub fn app_folder(&self, app_name: &str, app_version: &Version) -> PathBuf {
+        self.root.join("apps").join(app_name).join(&app_version)
     }
 
     pub fn is_not_installable(&self, app: &AppVersion) -> bool {
@@ -21,7 +21,7 @@ impl Yard {
     }
 
     /// provides the path to the executable of the given application
-    pub fn load_app(&self, name: &str, version: &str, executable_filename: &str) -> Option<Executable> {
+    pub fn load_app(&self, name: &str, version: &Version, executable_filename: &str) -> Option<Executable> {
         let file_path = self.app_folder(name, version).join(executable_filename);
         if file_path.exists() {
             Some(Executable(file_path))
@@ -44,13 +44,13 @@ impl Yard {
     }
 
     /// provides the path to the given file that is part of the given application
-    fn not_installable_path(&self, app_name: &str, app_version: &str) -> PathBuf {
+    fn not_installable_path(&self, app_name: &str, app_version: &Version) -> PathBuf {
         self.app_folder(app_name, app_version).join("not_installable")
     }
 
     /// stores the given application consisting of the given executable file
     #[cfg(test)]
-    fn save_app_file(&self, name: &str, version: &str, file_name: &str, file_content: &[u8]) {
+    fn save_app_file(&self, name: &str, version: &Version, file_name: &str, file_content: &[u8]) {
         use std::io::Write;
         fs::create_dir_all(self.app_folder(name, version)).unwrap();
         let mut file = fs::File::create(self.app_folder(name, version).join(file_name)).unwrap();
@@ -66,7 +66,7 @@ mod tests {
     #[test]
     fn app_file_path() {
         let yard = Yard { root: PathBuf::from("/root") };
-        let have = yard.app_folder("shellcheck", "0.9.0").join("shellcheck.exe");
+        let have = yard.app_folder("shellcheck", "0.9.0".into()).join("shellcheck.exe");
         let want = PathBuf::from("/root/apps/shellcheck/0.9.0/shellcheck.exe");
         assert_eq!(have, want);
     }

--- a/src/yard/yard.rs
+++ b/src/yard/yard.rs
@@ -60,13 +60,14 @@ impl Yard {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::Version;
     use crate::yard::Yard;
     use std::path::PathBuf;
 
     #[test]
     fn app_file_path() {
         let yard = Yard { root: PathBuf::from("/root") };
-        let have = yard.app_folder("shellcheck", &"0.9.0".into()).join("shellcheck.exe");
+        let have = yard.app_folder("shellcheck", &Version::from("0.9.0").into()).join("shellcheck.exe");
         let want = PathBuf::from("/root/apps/shellcheck/0.9.0/shellcheck.exe");
         assert_eq!(have, want);
     }
@@ -74,7 +75,7 @@ mod tests {
     #[test]
     fn app_folder() {
         let yard = Yard { root: PathBuf::from("/root") };
-        let have = yard.app_folder("shellcheck", &"0.9.0".into());
+        let have = yard.app_folder("shellcheck", &Version::from("0.9.0").into());
         let want = PathBuf::from("/root/apps/shellcheck/0.9.0");
         assert_eq!(have, want);
     }
@@ -112,7 +113,7 @@ mod tests {
     }
 
     mod load_app {
-        use crate::config::AppVersion;
+        use crate::config::{AppVersion, Version};
         use crate::subshell::Executable;
         use crate::yard::{create, Yard};
         use big_s::S;
@@ -123,8 +124,8 @@ mod tests {
             let tempdir = tempfile::tempdir().unwrap();
             let yard = create(tempdir.path()).unwrap();
             let executable = "executable";
-            yard.save_app_file("shellcheck", &"0.9.0".into(), executable, b"content");
-            let Some(Executable(executable_path)) = yard.load_app("shellcheck", &"0.9.0".into(), executable) else {
+            yard.save_app_file("shellcheck", &Version::from("0.9.0"), executable, b"content");
+            let Some(Executable(executable_path)) = yard.load_app("shellcheck", &Version::from("0.9.0"), executable) else {
                 panic!();
             };
             #[cfg(unix)]
@@ -157,8 +158,8 @@ mod tests {
             let tempdir = tempfile::tempdir().unwrap();
             let yard = create(tempdir.path()).unwrap();
             let executable = "executable";
-            yard.save_app_file("shellcheck", &"0.1.0".into(), executable, b"content");
-            let loaded = yard.load_app("shellcheck", &"0.9.0".into(), "executable");
+            yard.save_app_file("shellcheck", &Version::from("0.1.0"), executable, b"content");
+            let loaded = yard.load_app("shellcheck", &Version::from("0.9.0"), "executable");
             assert!(loaded.is_none());
         }
     }
@@ -166,7 +167,7 @@ mod tests {
     #[test]
     fn not_installable_path() {
         let yard = Yard { root: PathBuf::from("/root") };
-        let have = yard.not_installable_path("shellcheck", &"0.9.0".into());
+        let have = yard.not_installable_path("shellcheck", &Version::from("0.9.0").into());
         let want = PathBuf::from("/root/apps/shellcheck/0.9.0/not_installable");
         assert_eq!(have, want);
     }

--- a/src/yard/yard.rs
+++ b/src/yard/yard.rs
@@ -13,7 +13,7 @@ pub struct Yard {
 impl Yard {
     /// provides the path to the folder containing the given application
     pub fn app_folder(&self, app_name: &str, app_version: &Version) -> PathBuf {
-        self.root.join("apps").join(app_name).join(&app_version)
+        self.root.join("apps").join(app_name).join(app_version)
     }
 
     pub fn is_not_installable(&self, app: &AppVersion) -> bool {

--- a/src/yard/yard.rs
+++ b/src/yard/yard.rs
@@ -66,7 +66,7 @@ mod tests {
     #[test]
     fn app_file_path() {
         let yard = Yard { root: PathBuf::from("/root") };
-        let have = yard.app_folder("shellcheck", "0.9.0".into()).join("shellcheck.exe");
+        let have = yard.app_folder("shellcheck", &"0.9.0".into()).join("shellcheck.exe");
         let want = PathBuf::from("/root/apps/shellcheck/0.9.0/shellcheck.exe");
         assert_eq!(have, want);
     }
@@ -74,7 +74,7 @@ mod tests {
     #[test]
     fn app_folder() {
         let yard = Yard { root: PathBuf::from("/root") };
-        let have = yard.app_folder("shellcheck", "0.9.0");
+        let have = yard.app_folder("shellcheck", &"0.9.0".into());
         let want = PathBuf::from("/root/apps/shellcheck/0.9.0");
         assert_eq!(have, want);
     }
@@ -92,7 +92,7 @@ mod tests {
             let yard = create(tempdir.path()).unwrap();
             let app_version = AppVersion {
                 name: S("shellcheck"),
-                version: S("0.9.0"),
+                version: "0.9.0".into(),
             };
             yard.mark_not_installable(&app_version).unwrap();
             let have = yard.is_not_installable(&app_version);
@@ -104,7 +104,7 @@ mod tests {
             let yard = Yard { root: PathBuf::from("/root") };
             let app_version = AppVersion {
                 name: S("shellcheck"),
-                version: S("0.9.0"),
+                version: "0.9.0".into(),
             };
             let have = yard.is_not_installable(&app_version);
             assert!(!have);
@@ -123,8 +123,8 @@ mod tests {
             let tempdir = tempfile::tempdir().unwrap();
             let yard = create(tempdir.path()).unwrap();
             let executable = "executable";
-            yard.save_app_file("shellcheck", "0.9.0", executable, b"content");
-            let Some(Executable(executable_path)) = yard.load_app("shellcheck", "0.9.0", executable) else {
+            yard.save_app_file("shellcheck", &"0.9.0".into(), executable, b"content");
+            let Some(Executable(executable_path)) = yard.load_app("shellcheck", &"0.9.0".into(), executable) else {
                 panic!();
             };
             #[cfg(unix)]
@@ -146,7 +146,7 @@ mod tests {
             let yard = Yard { root: PathBuf::from("/root") };
             let app_version = AppVersion {
                 name: S("shellcheck"),
-                version: S("0.9.0"),
+                version: "0.9.0".into(),
             };
             let loaded = yard.load_app(&app_version.name, &app_version.version, "executable");
             assert!(loaded.is_none());
@@ -157,8 +157,8 @@ mod tests {
             let tempdir = tempfile::tempdir().unwrap();
             let yard = create(tempdir.path()).unwrap();
             let executable = "executable";
-            yard.save_app_file("shellcheck", "0.1.0", executable, b"content");
-            let loaded = yard.load_app("shellcheck", "0.9.0", "executable");
+            yard.save_app_file("shellcheck", &"0.1.0".into(), executable, b"content");
+            let loaded = yard.load_app("shellcheck", &"0.9.0".into(), "executable");
             assert!(loaded.is_none());
         }
     }
@@ -166,7 +166,7 @@ mod tests {
     #[test]
     fn not_installable_path() {
         let yard = Yard { root: PathBuf::from("/root") };
-        let have = yard.not_installable_path("shellcheck", "0.9.0");
+        let have = yard.not_installable_path("shellcheck", &"0.9.0".into());
         let want = PathBuf::from("/root/apps/shellcheck/0.9.0/not_installable");
         assert_eq!(have, want);
     }


### PR DESCRIPTION
Version is a pretty commonly used string that is often used together with other strings like app name, tag, output, etc. Giving it its own type makes the API clearer and helps distinguish data types.