### PR TITLE
Lookup returns only version from config

### DIFF
--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -51,7 +51,7 @@ pub fn load_or_install(app_name: &AppName, mut version: Version, include_path: b
     if version.is_none() {
         let config = config::load()?;
         match config.lookup(app_name) {
-            Some(configured_version) => version = configured_version.version,
+            Some(configured_version) => version = configured_version,
             None => return Err(UserError::RunRequestMissingVersion),
         }
     }

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -1,4 +1,4 @@
-use super::AppName;
+use super::{AppName, Version};
 use crate::config::AppVersion;
 use std::fmt::Display;
 
@@ -8,8 +8,8 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn lookup(self, app_name: &AppName) -> Option<AppVersion> {
-        self.apps.into_iter().find(|app| app.app == app_name)
+    pub fn lookup(self, app_name: &AppName) -> Option<Version> {
+        self.apps.into_iter().find(|app| app.app == app_name).map(|app_version| app_version.version)
     }
 }
 


### PR DESCRIPTION
No point in returning the internal AppVersion instance since the only other field it contains is the app name, which is already known to the caller since it was provided as the search parameter.