### PR TITLE
Introduce executable filepath attribute

### DIFF
--- a/src/apps/actionlint.rs
+++ b/src/apps/actionlint.rs
@@ -45,7 +45,7 @@ impl App for ActionLint {
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}/cmd/actionlint@{version}"),
             target_folder: &yard.app_folder(&name, version),
-            executable_filename: self.executable_filename(platform),
+            executable_filepath: self.executable_filename(platform),
             output,
         })
     }

--- a/src/apps/actionlint.rs
+++ b/src/apps/actionlint.rs
@@ -26,6 +26,10 @@ impl App for ActionLint {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        self.executable_filename(platform)
+    }
+
     fn homepage(&self) -> &'static str {
         formatcp!("https://{ORG}.github.io/{REPO}")
     }
@@ -35,8 +39,8 @@ impl App for ActionLint {
         let result = packaged_executable::install(InstallArgs {
             app_name: &name,
             artifact_url: download_url(version, platform),
-            file_to_extract: self.executable_filename(platform),
-            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filename(platform)),
+            file_to_extract: self.executable_filepath(platform),
+            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filepath(platform)),
             output,
         })?;
         if result.is_some() {
@@ -45,7 +49,7 @@ impl App for ActionLint {
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}/cmd/actionlint@{version}"),
             target_folder: &yard.app_folder(&name, version),
-            executable_filepath: self.executable_filename(platform),
+            executable_filepath: self.executable_filepath(platform),
             output,
         })
     }
@@ -55,7 +59,7 @@ impl App for ActionLint {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, self.executable_filename(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/alphavet.rs
+++ b/src/apps/alphavet.rs
@@ -25,6 +25,10 @@ impl App for Alphavet {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        self.executable_filename(platform)
+    }
+
     fn homepage(&self) -> &'static str {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
@@ -34,7 +38,7 @@ impl App for Alphavet {
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}/cmd/alphavet@v{version}"),
             target_folder: &yard.app_folder(&self.name(), version),
-            executable_filepath: self.executable_filename(platform),
+            executable_filepath: self.executable_filepath(platform),
             output,
         })
     }
@@ -44,7 +48,7 @@ impl App for Alphavet {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, self.executable_filename(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/alphavet.rs
+++ b/src/apps/alphavet.rs
@@ -34,7 +34,7 @@ impl App for Alphavet {
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}/cmd/alphavet@v{version}"),
             target_folder: &yard.app_folder(&self.name(), version),
-            executable_filename: self.executable_filename(platform),
+            executable_filepath: self.executable_filename(platform),
             output,
         })
     }

--- a/src/apps/deadcode.rs
+++ b/src/apps/deadcode.rs
@@ -21,6 +21,10 @@ impl App for Deadcode {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        self.executable_filename(platform)
+    }
+
     fn homepage(&self) -> &'static str {
         formatcp!("https://pkg.go.dev/golang.org/x/tools/cmd/deadcode")
     }
@@ -29,7 +33,7 @@ impl App for Deadcode {
         compile_go(CompileArgs {
             import_path: format!("golang.org/x/tools/cmd/deadcode@v{version}"),
             target_folder: &yard.app_folder(&self.name(), version),
-            executable_filepath: self.executable_filename(platform),
+            executable_filepath: self.executable_filepath(platform),
             output,
         })
     }
@@ -40,7 +44,7 @@ impl App for Deadcode {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, self.executable_filename(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, _amount: usize, _output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/deadcode.rs
+++ b/src/apps/deadcode.rs
@@ -29,7 +29,7 @@ impl App for Deadcode {
         compile_go(CompileArgs {
             import_path: format!("golang.org/x/tools/cmd/deadcode@v{version}"),
             target_folder: &yard.app_folder(&self.name(), version),
-            executable_filename: self.executable_filename(platform),
+            executable_filepath: self.executable_filename(platform),
             output,
         })
     }

--- a/src/apps/depth.rs
+++ b/src/apps/depth.rs
@@ -44,7 +44,7 @@ impl App for Depth {
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}/cmd/depth@v{version}"),
             target_folder: &yard.app_folder(&name, version),
-            executable_filename: self.executable_filename(platform),
+            executable_filepath: self.executable_filename(platform),
             output,
         })
     }

--- a/src/apps/depth.rs
+++ b/src/apps/depth.rs
@@ -26,6 +26,10 @@ impl App for Depth {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        self.executable_filename(platform)
+    }
+
     fn homepage(&self) -> &'static str {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
@@ -35,7 +39,7 @@ impl App for Depth {
         let result = executable::install(InstallArgs {
             app_name: &name,
             artifact_url: download_url(version, platform),
-            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filepath(platform)),
             output,
         })?;
         if result.is_some() {
@@ -44,7 +48,7 @@ impl App for Depth {
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}/cmd/depth@v{version}"),
             target_folder: &yard.app_folder(&name, version),
-            executable_filepath: self.executable_filename(platform),
+            executable_filepath: self.executable_filepath(platform),
             output,
         })
     }
@@ -54,7 +58,7 @@ impl App for Depth {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, self.executable_filename(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/dprint.rs
+++ b/src/apps/dprint.rs
@@ -25,6 +25,10 @@ impl App for Dprint {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        self.executable_filename(platform)
+    }
+
     fn homepage(&self) -> &'static str {
         "https://dprint.dev"
     }
@@ -34,8 +38,8 @@ impl App for Dprint {
         let result = packaged_executable::install(InstallArgs {
             app_name: &name,
             artifact_url: download_url(version, platform),
-            file_to_extract: self.executable_filename(platform),
-            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filename(platform)),
+            file_to_extract: self.executable_filepath(platform),
+            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filepath(platform)),
             output,
         })?;
         if result.is_some() {
@@ -44,7 +48,7 @@ impl App for Dprint {
         compile_rust(CompileArgs {
             crate_name: "dprint",
             target_folder: yard.app_folder(&name, version),
-            executable_filepath: self.executable_filename(platform),
+            executable_filepath: self.executable_filepath(platform),
             output,
         })
     }
@@ -54,7 +58,7 @@ impl App for Dprint {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, self.executable_filename(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/dprint.rs
+++ b/src/apps/dprint.rs
@@ -44,7 +44,7 @@ impl App for Dprint {
         compile_rust(CompileArgs {
             crate_name: "dprint",
             target_folder: yard.app_folder(&name, version),
-            executable_filename: self.executable_filename(platform),
+            executable_filepath: self.executable_filename(platform),
             output,
         })
     }

--- a/src/apps/gh.rs
+++ b/src/apps/gh.rs
@@ -24,6 +24,10 @@ impl App for Gh {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        self.executable_filename(platform)
+    }
+
     fn homepage(&self) -> &'static str {
         "https://cli.github.com"
     }
@@ -34,7 +38,7 @@ impl App for Gh {
             app_name: &name,
             artifact_url: download_url(version, platform),
             file_to_extract: &executable_path(version, platform),
-            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filepath(platform)),
             output,
         })
         // installation from source seems more involved, see https://github.com/cli/cli/blob/trunk/docs/source.md
@@ -45,7 +49,7 @@ impl App for Gh {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, self.executable_filename(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/ghokin.rs
+++ b/src/apps/ghokin.rs
@@ -26,6 +26,10 @@ impl App for Ghokin {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        self.executable_filename(platform)
+    }
+
     fn homepage(&self) -> &'static str {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
@@ -35,8 +39,8 @@ impl App for Ghokin {
         let result = packaged_executable::install(InstallArgs {
             app_name: &name,
             artifact_url: download_url(version, platform),
-            file_to_extract: self.executable_filename(platform),
-            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filename(platform)),
+            file_to_extract: self.executable_filepath(platform),
+            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filepath(platform)),
             output,
         })?;
         if result.is_some() {
@@ -45,7 +49,7 @@ impl App for Ghokin {
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}/v3@v{version}"),
             target_folder: &yard.app_folder(&name, version),
-            executable_filepath: self.executable_filename(platform),
+            executable_filepath: self.executable_filepath(platform),
             output,
         })
     }
@@ -55,7 +59,7 @@ impl App for Ghokin {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, self.executable_filename(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/ghokin.rs
+++ b/src/apps/ghokin.rs
@@ -45,7 +45,7 @@ impl App for Ghokin {
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}/v3@v{version}"),
             target_folder: &yard.app_folder(&name, version),
-            executable_filename: self.executable_filename(platform),
+            executable_filepath: self.executable_filename(platform),
             output,
         })
     }

--- a/src/apps/go.rs
+++ b/src/apps/go.rs
@@ -25,6 +25,13 @@ impl App for Go {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        match platform.os {
+            Os::Linux | Os::MacOS => "bin/go",
+            Os::Windows => "bin\\go.exe",
+        }
+    }
+
     fn homepage(&self) -> &'static str {
         "https://go.dev"
     }
@@ -36,7 +43,7 @@ impl App for Go {
             artifact_url: download_url(version, platform),
             dir_on_disk: yard.app_folder(&name, version),
             strip_path_prefix: "go/",
-            executable_in_archive: &self.executable_path(platform),
+            executable_in_archive: self.executable_filepath(platform),
             output,
         })
     }
@@ -47,7 +54,7 @@ impl App for Go {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, &self.executable_path(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
@@ -58,16 +65,6 @@ impl App for Go {
             go_tags.resize(amount, S(""));
         }
         Ok(go_tags.into_iter().map(Version::from).collect())
-    }
-}
-
-impl Go {
-    fn executable_path(&self, platform: Platform) -> String {
-        let executable = self.executable_filename(platform);
-        match platform.os {
-            Os::Windows => format!("bin\\{executable}"),
-            Os::Linux | Os::MacOS => format!("bin/{executable}"),
-        }
     }
 }
 

--- a/src/apps/goda.rs
+++ b/src/apps/goda.rs
@@ -33,7 +33,7 @@ impl App for Goda {
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}@v{version}"),
             target_folder: &yard.app_folder(&self.name(), version),
-            executable_filename: self.executable_filename(platform),
+            executable_filepath: self.executable_filename(platform),
             output,
         })
     }

--- a/src/apps/goda.rs
+++ b/src/apps/goda.rs
@@ -25,6 +25,10 @@ impl App for Goda {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        self.executable_filename(platform)
+    }
+
     fn homepage(&self) -> &'static str {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
@@ -33,7 +37,7 @@ impl App for Goda {
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}@v{version}"),
             target_folder: &yard.app_folder(&self.name(), version),
-            executable_filepath: self.executable_filename(platform),
+            executable_filepath: self.executable_filepath(platform),
             output,
         })
     }
@@ -43,7 +47,7 @@ impl App for Goda {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, self.executable_filename(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/gofmt.rs
+++ b/src/apps/gofmt.rs
@@ -20,6 +20,13 @@ impl App for Gofmt {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        match platform.os {
+            Os::Linux | Os::MacOS => "bin/go",
+            Os::Windows => "bin\\go.exe",
+        }
+    }
+
     fn homepage(&self) -> &'static str {
         "https://go.dev"
     }
@@ -27,7 +34,7 @@ impl App for Gofmt {
     fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let go = Go {};
         go.install(version, platform, yard, output)?;
-        let executable_path = yard.app_folder(&go.name(), version).join(self.executable_filename(platform));
+        let executable_path = yard.app_folder(&go.name(), version).join(self.executable_filepath(platform));
         Ok(Some(Executable(executable_path)))
     }
 
@@ -36,20 +43,10 @@ impl App for Gofmt {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&(Go {}).name(), version, &self.executable_path(platform))
+        yard.load_app(&(Go {}).name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
         (Go {}).installable_versions(amount, output)
-    }
-}
-
-impl Gofmt {
-    fn executable_path(&self, platform: Platform) -> String {
-        let executable = self.executable_filename(platform);
-        match platform.os {
-            Os::Windows => format!("bin\\{executable}"),
-            Os::Linux | Os::MacOS => format!("bin/{executable}"),
-        }
     }
 }

--- a/src/apps/gofumpt.rs
+++ b/src/apps/gofumpt.rs
@@ -26,6 +26,10 @@ impl App for Gofumpt {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        self.executable_filename(platform)
+    }
+
     fn homepage(&self) -> &'static str {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
@@ -39,7 +43,7 @@ impl App for Gofumpt {
         let result = executable::install(InstallArgs {
             app_name: &name,
             artifact_url: download_url(version, platform),
-            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filepath(platform)),
             output,
         })?;
         if result.is_some() {
@@ -48,13 +52,13 @@ impl App for Gofumpt {
         compile_go(CompileArgs {
             import_path: format!("mvdan.cc/gofumpt@{version}"),
             target_folder: &yard.app_folder(&name, version),
-            executable_filepath: self.executable_filename(platform),
+            executable_filepath: self.executable_filepath(platform),
             output,
         })
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, self.executable_filename(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/gofumpt.rs
+++ b/src/apps/gofumpt.rs
@@ -48,7 +48,7 @@ impl App for Gofumpt {
         compile_go(CompileArgs {
             import_path: format!("mvdan.cc/gofumpt@{version}"),
             target_folder: &yard.app_folder(&name, version),
-            executable_filename: self.executable_filename(platform),
+            executable_filepath: self.executable_filename(platform),
             output,
         })
     }

--- a/src/apps/golangci_lint.rs
+++ b/src/apps/golangci_lint.rs
@@ -25,6 +25,10 @@ impl App for GolangCiLint {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        self.executable_filename(platform)
+    }
+
     fn homepage(&self) -> &'static str {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
@@ -34,8 +38,8 @@ impl App for GolangCiLint {
         packaged_executable::install(InstallArgs {
             app_name: &name,
             artifact_url: download_url(version, platform),
-            file_to_extract: &executable_path(version, platform, self.executable_filename(platform)),
-            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filename(platform)),
+            file_to_extract: &executable_path(version, platform, self.executable_filepath(platform)),
+            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filepath(platform)),
             output,
         })
         // install from source not recommended, see https://golangci-lint.run/usage/install/#install-from-source
@@ -46,7 +50,7 @@ impl App for GolangCiLint {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, self.executable_filename(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/goreleaser.rs
+++ b/src/apps/goreleaser.rs
@@ -25,6 +25,10 @@ impl App for Goreleaser {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        self.executable_filename(platform)
+    }
+
     fn homepage(&self) -> &'static str {
         "https://goreleaser.com"
     }
@@ -34,8 +38,8 @@ impl App for Goreleaser {
         let result = packaged_executable::install(InstallArgs {
             app_name: &name,
             artifact_url: download_url(version, platform),
-            file_to_extract: self.executable_filename(platform),
-            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filename(platform)),
+            file_to_extract: self.executable_filepath(platform),
+            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filepath(platform)),
             output,
         })?;
         if result.is_some() {
@@ -44,7 +48,7 @@ impl App for Goreleaser {
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}@{version}"),
             target_folder: &yard.app_folder(&name, version),
-            executable_filepath: self.executable_filename(platform),
+            executable_filepath: self.executable_filepath(platform),
             output,
         })
     }
@@ -54,7 +58,7 @@ impl App for Goreleaser {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, self.executable_filename(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/goreleaser.rs
+++ b/src/apps/goreleaser.rs
@@ -44,7 +44,7 @@ impl App for Goreleaser {
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}@{version}"),
             target_folder: &yard.app_folder(&name, version),
-            executable_filename: self.executable_filename(platform),
+            executable_filepath: self.executable_filename(platform),
             output,
         })
     }

--- a/src/apps/mdbook.rs
+++ b/src/apps/mdbook.rs
@@ -26,6 +26,10 @@ impl App for MdBook {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        self.executable_filename(platform)
+    }
+
     fn homepage(&self) -> &'static str {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
@@ -35,8 +39,8 @@ impl App for MdBook {
         let result = packaged_executable::install(InstallArgs {
             app_name: &name,
             artifact_url: download_url(version, platform),
-            file_to_extract: self.executable_filename(platform),
-            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filename(platform)),
+            file_to_extract: self.executable_filepath(platform),
+            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filepath(platform)),
             output,
         })?;
         if result.is_some() {
@@ -45,7 +49,7 @@ impl App for MdBook {
         compile_rust(CompileArgs {
             crate_name: "mdbook",
             target_folder: yard.app_folder(&name, version),
-            executable_filepath: self.executable_filename(platform),
+            executable_filepath: self.executable_filepath(platform),
             output,
         })
     }
@@ -55,7 +59,7 @@ impl App for MdBook {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, self.executable_filename(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/mdbook.rs
+++ b/src/apps/mdbook.rs
@@ -45,7 +45,7 @@ impl App for MdBook {
         compile_rust(CompileArgs {
             crate_name: "mdbook",
             target_folder: yard.app_folder(&name, version),
-            executable_filename: self.executable_filename(platform),
+            executable_filepath: self.executable_filename(platform),
             output,
         })
     }

--- a/src/apps/mod.rs
+++ b/src/apps/mod.rs
@@ -36,6 +36,9 @@ pub trait App {
     /// the filename of the executable that starts this app
     fn executable_filename(&self, platform: Platform) -> &'static str;
 
+    /// relative path of the executable that starts this app in the folder the downloaded artifact gets unpacked into
+    fn executable_filepath(&self, platform: Platform) -> &'static str;
+
     /// link to the (human-readable) homepage of the app
     fn homepage(&self) -> &'static str;
 

--- a/src/apps/nodejs.rs
+++ b/src/apps/nodejs.rs
@@ -24,6 +24,13 @@ impl App for NodeJS {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        match platform.os {
+            Os::Windows => "bin\\node.exe",
+            Os::Linux | Os::MacOS => "bin/node",
+        }
+    }
+
     fn homepage(&self) -> &'static str {
         "https://nodejs.org"
     }
@@ -35,7 +42,7 @@ impl App for NodeJS {
             artifact_url: download_url(version, platform),
             dir_on_disk: yard.app_folder(&name, version),
             strip_path_prefix: &format!("node-v{version}-{os}-{cpu}/", os = os_text(platform.os), cpu = cpu_text(platform.cpu)),
-            executable_in_archive: executable_path(platform),
+            executable_in_archive: self.executable_filepath(platform),
             output,
         })
     }
@@ -45,7 +52,7 @@ impl App for NodeJS {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, executable_path(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {
@@ -60,13 +67,6 @@ pub fn download_url(version: &Version, platform: Platform) -> String {
         cpu = cpu_text(platform.cpu),
         ext = ext_text(platform.os)
     )
-}
-
-fn executable_path(platform: Platform) -> &'static str {
-    match platform.os {
-        Os::Windows => "bin\\node.exe",
-        Os::Linux | Os::MacOS => "bin/node",
-    }
 }
 
 fn os_text(os: Os) -> &'static str {

--- a/src/apps/npm.rs
+++ b/src/apps/npm.rs
@@ -15,6 +15,13 @@ impl App for Npm {
 
     fn executable_filename(&self, platform: Platform) -> &'static str {
         match platform.os {
+            Os::Linux | Os::MacOS => "npm",
+            Os::Windows => "npm.exe",
+        }
+    }
+
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        match platform.os {
             Os::Linux | Os::MacOS => "bin/npm",
             Os::Windows => "bin\\npm.exe",
         }
@@ -27,7 +34,7 @@ impl App for Npm {
     fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let nodejs = NodeJS {};
         nodejs.install(version, platform, yard, output)?;
-        let executable_path = yard.app_folder(&nodejs.name(), version).join(self.executable_filename(platform));
+        let executable_path = yard.app_folder(&nodejs.name(), version).join(self.executable_filepath(platform));
         Ok(Some(Executable(executable_path)))
     }
 
@@ -36,7 +43,7 @@ impl App for Npm {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&(NodeJS {}).name(), version, self.executable_filename(platform))
+        yard.load_app(&(NodeJS {}).name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/npx.rs
+++ b/src/apps/npx.rs
@@ -15,6 +15,13 @@ impl App for Npx {
 
     fn executable_filename(&self, platform: Platform) -> &'static str {
         match platform.os {
+            Os::Linux | Os::MacOS => "npx",
+            Os::Windows => "npx.exe",
+        }
+    }
+
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        match platform.os {
             Os::Linux | Os::MacOS => "bin/npx",
             Os::Windows => "bin\\npx.exe",
         }
@@ -27,7 +34,7 @@ impl App for Npx {
     fn install(&self, version: &Version, platform: Platform, yard: &Yard, output: &dyn Output) -> Result<Option<Executable>> {
         let nodejs = NodeJS {};
         nodejs.install(version, platform, yard, output)?;
-        let executable_path = yard.app_folder(&nodejs.name(), version).join(self.executable_filename(platform));
+        let executable_path = yard.app_folder(&nodejs.name(), version).join(self.executable_filepath(platform));
         Ok(Some(Executable(executable_path)))
     }
 
@@ -36,7 +43,7 @@ impl App for Npx {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&(NodeJS {}).name(), version, self.executable_filename(platform))
+        yard.load_app(&(NodeJS {}).name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/scc.rs
+++ b/src/apps/scc.rs
@@ -45,7 +45,7 @@ impl App for Scc {
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}/v3@v{version}"),
             target_folder: &yard.app_folder(&name, version),
-            executable_filename: self.executable_filename(platform),
+            executable_filepath: self.executable_filename(platform),
             output,
         })
     }

--- a/src/apps/scc.rs
+++ b/src/apps/scc.rs
@@ -26,6 +26,10 @@ impl App for Scc {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        self.executable_filename(platform)
+    }
+
     fn homepage(&self) -> &'static str {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
@@ -35,8 +39,8 @@ impl App for Scc {
         let result = packaged_executable::install(InstallArgs {
             app_name: &name,
             artifact_url: download_url(version, platform),
-            file_to_extract: self.executable_filename(platform),
-            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filename(platform)),
+            file_to_extract: self.executable_filepath(platform),
+            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filepath(platform)),
             output,
         })?;
         if result.is_some() {
@@ -45,7 +49,7 @@ impl App for Scc {
         compile_go(CompileArgs {
             import_path: format!("github.com/{ORG}/{REPO}/v3@v{version}"),
             target_folder: &yard.app_folder(&name, version),
-            executable_filepath: self.executable_filename(platform),
+            executable_filepath: self.executable_filepath(platform),
             output,
         })
     }
@@ -55,7 +59,7 @@ impl App for Scc {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, self.executable_filename(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/shellcheck.rs
+++ b/src/apps/shellcheck.rs
@@ -24,6 +24,10 @@ impl App for ShellCheck {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        self.executable_filename(platform)
+    }
+
     fn homepage(&self) -> &'static str {
         "https://www.shellcheck.net"
     }
@@ -33,8 +37,8 @@ impl App for ShellCheck {
         packaged_executable::install(InstallArgs {
             app_name: &name,
             artifact_url: download_url(version, platform),
-            file_to_extract: &format!("shellcheck-v{version}/{executable}", executable = self.executable_filename(platform)),
-            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filename(platform)),
+            file_to_extract: &format!("shellcheck-v{version}/{executable}", executable = self.executable_filepath(platform)),
+            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filepath(platform)),
             output,
         })
     }
@@ -44,7 +48,7 @@ impl App for ShellCheck {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, self.executable_filename(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/shfmt.rs
+++ b/src/apps/shfmt.rs
@@ -26,6 +26,10 @@ impl App for Shfmt {
         }
     }
 
+    fn executable_filepath(&self, platform: Platform) -> &'static str {
+        self.executable_filename(platform)
+    }
+
     fn homepage(&self) -> &'static str {
         formatcp!("https://github.com/{ORG}/{REPO}")
     }
@@ -35,7 +39,7 @@ impl App for Shfmt {
         let result = executable::install(InstallArgs {
             app_name: &name,
             artifact_url: download_url(version, platform),
-            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filename(platform)),
+            filepath_on_disk: yard.app_folder(&name, version).join(self.executable_filepath(platform)),
             output,
         })?;
         if result.is_some() {
@@ -44,7 +48,7 @@ impl App for Shfmt {
         compile_go(CompileArgs {
             import_path: format!("mvdan.cc/sh/v3/cmd/shfmt@v{version}"),
             target_folder: &yard.app_folder(&name, version),
-            executable_filepath: self.executable_filename(platform),
+            executable_filepath: self.executable_filepath(platform),
             output,
         })
     }
@@ -54,7 +58,7 @@ impl App for Shfmt {
     }
 
     fn load(&self, version: &Version, platform: Platform, yard: &Yard) -> Option<Executable> {
-        yard.load_app(&self.name(), version, self.executable_filename(platform))
+        yard.load_app(&self.name(), version, self.executable_filepath(platform))
     }
 
     fn installable_versions(&self, amount: usize, output: &dyn Output) -> Result<Vec<Version>> {

--- a/src/apps/shfmt.rs
+++ b/src/apps/shfmt.rs
@@ -44,7 +44,7 @@ impl App for Shfmt {
         compile_go(CompileArgs {
             import_path: format!("mvdan.cc/sh/v3/cmd/shfmt@v{version}"),
             target_folder: &yard.app_folder(&name, version),
-            executable_filename: self.executable_filename(platform),
+            executable_filepath: self.executable_filename(platform),
             output,
         })
     }

--- a/src/install/compile_go.rs
+++ b/src/install/compile_go.rs
@@ -33,7 +33,7 @@ pub fn compile_go(args: CompileArgs) -> Result<Option<Executable>> {
     if !status.success() {
         return Err(UserError::GoCompilationFailed);
     }
-    let executable = Executable(args.target_folder.join(args.executable_filename));
+    let executable = Executable(args.target_folder.join(args.executable_filepath));
     drop(args);
     Ok(Some(executable))
 }
@@ -42,6 +42,6 @@ pub struct CompileArgs<'a> {
     /// the fully qualified Go import path for the package to install
     pub import_path: String,
     pub target_folder: &'a Path,
-    pub executable_filename: &'static str,
+    pub executable_filepath: &'static str,
     pub output: &'a dyn Output,
 }

--- a/src/install/compile_rust.rs
+++ b/src/install/compile_rust.rs
@@ -28,7 +28,7 @@ pub fn compile_rust(args: CompileArgs) -> Result<Option<Executable>> {
     if !status.success() {
         return Err(UserError::RustCompilationFailed);
     }
-    let executable = Executable(args.target_folder.join(args.executable_filename));
+    let executable = Executable(args.target_folder.join(args.executable_filepath));
     drop(args);
     Ok(Some(executable))
 }
@@ -36,6 +36,6 @@ pub fn compile_rust(args: CompileArgs) -> Result<Option<Executable>> {
 pub struct CompileArgs<'a> {
     pub crate_name: &'static str,
     pub target_folder: PathBuf,
-    pub executable_filename: &'static str,
+    pub executable_filepath: &'static str,
     pub output: &'a dyn Output,
 }

--- a/src/yard/yard.rs
+++ b/src/yard/yard.rs
@@ -21,8 +21,8 @@ impl Yard {
     }
 
     /// provides the path to the executable of the given application
-    pub fn load_app(&self, name: &AppName, version: &Version, executable_filename: &str) -> Option<Executable> {
-        let file_path = self.app_folder(name, version).join(executable_filename);
+    pub fn load_app(&self, name: &AppName, version: &Version, executable_filepath: &str) -> Option<Executable> {
+        let file_path = self.app_folder(name, version).join(executable_filepath);
         if file_path.exists() {
             Some(Executable(file_path))
         } else {


### PR DESCRIPTION
The old "filename" attribute was used for the relative filepath, and sometimes providing it. This PR introduces a distinction between executable filename and filepath.