### PR TITLE
Move deriving higher-level data into command implementations

### DIFF
--- a/src/cmd/available.rs
+++ b/src/cmd/available.rs
@@ -13,7 +13,7 @@ pub fn available(app_name: &AppName, version: Option<Version>, log: Option<Strin
     let app = apps.lookup(app_name)?;
     let output = output::StdErr { category: log };
     let platform = platform::detect(&output)?;
-    let versions = RequestedVersions::determine(&app_name, version)?;
+    let versions = RequestedVersions::determine(app_name, version)?;
     for version in versions.iter() {
         if load_or_install(app, version, platform, &output)?.is_some() {
             return Ok(ExitCode::SUCCESS);

--- a/src/cmd/available.rs
+++ b/src/cmd/available.rs
@@ -2,17 +2,20 @@ use super::run::load_or_install;
 use crate::apps;
 use crate::config::AppName;
 use crate::config::RequestedVersions;
+use crate::config::Version;
+use crate::output;
 use crate::platform;
-use crate::Output;
 use crate::Result;
 use std::process::ExitCode;
 
-pub fn available(app: &AppName, versions: &RequestedVersions, output: &dyn Output) -> Result<ExitCode> {
+pub fn available(app_name: &AppName, version: Option<Version>, log: Option<String>) -> Result<ExitCode> {
     let apps = apps::all();
-    let app = apps.lookup(app)?;
-    let platform = platform::detect(output)?;
+    let app = apps.lookup(app_name)?;
+    let output = output::StdErr { category: log };
+    let platform = platform::detect(&output)?;
+    let versions = RequestedVersions::determine(&app_name, version)?;
     for version in versions.iter() {
-        if load_or_install(app, version, platform, output)?.is_some() {
+        if load_or_install(app, version, platform, &output)?.is_some() {
             return Ok(ExitCode::SUCCESS);
         }
     }

--- a/src/cmd/available.rs
+++ b/src/cmd/available.rs
@@ -1,13 +1,18 @@
 use super::run::load_or_install;
+use crate::apps;
 use crate::config::AppName;
 use crate::config::RequestedVersions;
+use crate::platform;
 use crate::Output;
 use crate::Result;
 use std::process::ExitCode;
 
 pub fn available(app: &AppName, versions: &RequestedVersions, output: &dyn Output) -> Result<ExitCode> {
+    let apps = apps::all();
+    let app = apps.lookup(app)?;
+    let platform = platform::detect(output)?;
     for version in versions.iter() {
-        if load_or_install(app, version, output)?.is_some() {
+        if load_or_install(app, version, platform, output)?.is_some() {
             return Ok(ExitCode::SUCCESS);
         }
     }

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -1,8 +1,8 @@
-use crate::apps::AnalyzeResult;
+use crate::apps::{AnalyzeResult, App};
 use crate::config::{AppName, RequestedVersion, RequestedVersions, Version};
 use crate::error::UserError;
 use crate::filesystem::find_global_install;
-use crate::platform;
+use crate::platform::{self, Platform};
 use crate::subshell;
 use crate::subshell::Executable;
 use crate::yard;
@@ -13,8 +13,11 @@ use colored::Colorize;
 use std::process::ExitCode;
 
 pub fn run(args: &Args) -> Result<ExitCode> {
+    let apps = apps::all();
+    let app = apps.lookup(&args.app)?;
+    let platform = platform::detect(args.output)?;
     for version in args.versions.iter() {
-        if let Some(executable) = load_or_install(&args.app, version, args.output)? {
+        if let Some(executable) = load_or_install(app, version, platform, args.output)? {
             if args.error_on_output {
                 return subshell::execute_check_output(&executable, &args.app_args);
             }
@@ -49,18 +52,15 @@ pub struct Args<'a> {
     pub output: &'a dyn Output,
 }
 
-pub fn load_or_install(app_name: &AppName, version: &RequestedVersion, output: &dyn Output) -> Result<Option<Executable>> {
+pub fn load_or_install(app: &dyn App, version: &RequestedVersion, platform: Platform, output: &dyn Output) -> Result<Option<Executable>> {
     match version {
-        RequestedVersion::Path(version) => load_from_path(app_name, &parse_semver_req(version)?, output),
-        RequestedVersion::Yard(version) => load_or_install_from_yard(app_name, version, output),
+        RequestedVersion::Path(version) => load_from_path(app, &parse_semver_req(version)?, platform, output),
+        RequestedVersion::Yard(version) => load_or_install_from_yard(app, version, output),
     }
 }
 
 // checks if the app is in the PATH and has the correct version
-fn load_from_path(app_name: &AppName, want_version: &semver::VersionReq, output: &dyn Output) -> Result<Option<Executable>> {
-    let apps = apps::all();
-    let app = apps.lookup(app_name)?;
-    let platform = platform::detect(output)?;
+fn load_from_path(app: &dyn App, want_version: &semver::VersionReq, platform: Platform, output: &dyn Output) -> Result<Option<Executable>> {
     let Some(executable) = find_global_install(app.executable_filename(platform), output) else {
         return Ok(None);
     };
@@ -69,7 +69,7 @@ fn load_from_path(app_name: &AppName, want_version: &semver::VersionReq, output:
             output.println(&format!(
                 "found {} but it doesn't seem an {} executable",
                 executable.as_str().cyan().bold(),
-                app_name.as_str().cyan().bold()
+                app.name().as_str().cyan().bold()
             ));
             Ok(None)
         }
@@ -78,7 +78,7 @@ fn load_from_path(app_name: &AppName, want_version: &semver::VersionReq, output:
             output.println(&format!(
                 "{} is an {} executable but I'm unable to determine its version.",
                 executable.as_str().cyan().bold(),
-                app_name.as_str().cyan().bold(),
+                app.name().as_str().cyan().bold(),
             ));
             Ok(None)
         }
@@ -96,21 +96,19 @@ fn load_from_path(app_name: &AppName, want_version: &semver::VersionReq, output:
     }
 }
 
-fn load_or_install_from_yard(app_name: &AppName, version: &Version, output: &dyn Output) -> Result<Option<Executable>> {
-    let apps = apps::all();
-    let app = apps.lookup(app_name)?;
+fn load_or_install_from_yard(app: &dyn App, version: &Version, output: &dyn Output) -> Result<Option<Executable>> {
     let platform = platform::detect(output)?;
     let yard = yard::load_or_create(&yard::production_location()?)?;
     if let Some(executable) = app.load(version, platform, &yard) {
         return Ok(Some(executable));
     };
-    if yard.is_not_installable(app_name, version) {
+    if yard.is_not_installable(&app.name(), version) {
         return Ok(None);
     }
     if let Some(executable) = app.install(version, platform, &yard, output)? {
         return Ok(Some(executable));
     }
-    yard.mark_not_installable(app_name, version)?;
+    yard.mark_not_installable(&app.name(), version)?;
     Ok(None)
 }
 

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -17,7 +17,8 @@ pub fn run(args: Args) -> Result<ExitCode> {
     let app = apps.lookup(&args.app)?;
     let output = output::StdErr { category: args.log };
     let platform = platform::detect(&output)?;
-    for version in args.versions.iter() {
+    let versions = RequestedVersions::determine(&args.app, args.version)?;
+    for version in versions.iter() {
         if let Some(executable) = load_or_install(app, version, platform, &output)? {
             if args.error_on_output {
                 return subshell::execute_check_output(&executable, &args.app_args);
@@ -38,7 +39,7 @@ pub struct Args {
     pub app: AppName,
 
     /// possible versions of the app to execute
-    pub versions: RequestedVersions,
+    pub version: Option<Version>,
 
     /// arguments to call the app with
     #[allow(clippy::struct_field_names)]

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -1,17 +1,18 @@
-use crate::apps;
 use crate::config::Config;
 use crate::output::Output;
 use crate::Result;
+use crate::{apps, output};
 use colored::Colorize;
 use std::process::ExitCode;
 
-pub fn update(output: &dyn Output) -> Result<ExitCode> {
+pub fn update(log: Option<String>) -> Result<ExitCode> {
     let mut config = Config::load()?;
     let all_apps = apps::all();
+    let output = output::StdErr { category: log };
     for old_app in &mut config.apps {
         let app = all_apps.lookup(&old_app.app)?;
         output.print(&format!("updating {} ... ", &old_app.app));
-        let latest = app.latest_installable_version(output)?;
+        let latest = app.latest_installable_version(&output)?;
         let latest_str = latest.to_string();
         if let Some(previous) = &old_app.versions.update_largest_with(&latest) {
             output.println(&format!("{} -> {}", previous.as_str().cyan(), latest_str.cyan()));

--- a/src/cmd/versions.rs
+++ b/src/cmd/versions.rs
@@ -1,13 +1,13 @@
-use crate::apps;
 use crate::config::AppName;
-use crate::output::Output;
 use crate::Result;
+use crate::{apps, output};
 use std::process::ExitCode;
 
-pub fn versions(app_name: &AppName, amount: usize, output: &dyn Output) -> Result<ExitCode> {
+pub fn versions(app_name: &AppName, amount: usize, log: Option<String>) -> Result<ExitCode> {
     let apps = &apps::all();
     let app = apps.lookup(app_name)?;
-    let versions = app.installable_versions(amount, output)?;
+    let output = output::StdErr { category: log };
+    let versions = app.installable_versions(amount, &output)?;
     println!("{app_name} is available in these versions:");
     for version in versions {
         println!("- {version}");

--- a/src/cmd/which.rs
+++ b/src/cmd/which.rs
@@ -11,7 +11,7 @@ pub fn which(app_name: &AppName, version: Option<Version>, log: Option<String>) 
     let app = apps.lookup(app_name)?;
     let output = output::StdErr { category: log };
     let platform = platform::detect(&output)?;
-    let versions = RequestedVersions::determine(&app_name, version)?;
+    let versions = RequestedVersions::determine(app_name, version)?;
     for version in versions.iter() {
         if let Some(executable) = load_or_install(app, version, platform, &output)? {
             println!("{}", executable.0.to_string_lossy());

--- a/src/cmd/which.rs
+++ b/src/cmd/which.rs
@@ -1,18 +1,18 @@
-use crate::apps;
 use crate::config::{AppName, RequestedVersions};
 use crate::platform;
-use crate::Output;
 use crate::Result;
+use crate::{apps, output};
 use std::process::ExitCode;
 
 use super::run::load_or_install;
 
-pub fn which(app: &AppName, versions: &RequestedVersions, output: &dyn Output) -> Result<ExitCode> {
+pub fn which(app: &AppName, versions: &RequestedVersions, log: Option<String>) -> Result<ExitCode> {
     let binding = apps::all();
     let app = binding.lookup(app)?;
-    let platform = platform::detect(output)?;
+    let output = output::StdErr { category: log };
+    let platform = platform::detect(&output)?;
     for version in versions.iter() {
-        if let Some(executable) = load_or_install(app, version, platform, output)? {
+        if let Some(executable) = load_or_install(app, version, platform, &output)? {
             println!("{}", executable.0.to_string_lossy());
             return Ok(ExitCode::SUCCESS);
         }

--- a/src/cmd/which.rs
+++ b/src/cmd/which.rs
@@ -1,6 +1,5 @@
 use crate::apps;
-use crate::config::AppName;
-use crate::config::RequestedVersions;
+use crate::config::{AppName, RequestedVersions};
 use crate::platform;
 use crate::Output;
 use crate::Result;
@@ -9,8 +8,8 @@ use std::process::ExitCode;
 use super::run::load_or_install;
 
 pub fn which(app: &AppName, versions: &RequestedVersions, output: &dyn Output) -> Result<ExitCode> {
-    let apps = apps::all();
-    let app = apps.lookup(app)?;
+    let binding = apps::all();
+    let app = binding.lookup(app)?;
     let platform = platform::detect(output)?;
     for version in versions.iter() {
         if let Some(executable) = load_or_install(app, version, platform, output)? {

--- a/src/cmd/which.rs
+++ b/src/cmd/which.rs
@@ -1,4 +1,4 @@
-use crate::config::{AppName, RequestedVersions};
+use crate::config::{AppName, RequestedVersions, Version};
 use crate::platform;
 use crate::Result;
 use crate::{apps, output};
@@ -6,11 +6,12 @@ use std::process::ExitCode;
 
 use super::run::load_or_install;
 
-pub fn which(app: &AppName, versions: &RequestedVersions, log: Option<String>) -> Result<ExitCode> {
+pub fn which(app_name: &AppName, version: Option<Version>, log: Option<String>) -> Result<ExitCode> {
     let binding = apps::all();
-    let app = binding.lookup(app)?;
+    let app = binding.lookup(app_name)?;
     let output = output::StdErr { category: log };
     let platform = platform::detect(&output)?;
+    let versions = RequestedVersions::determine(&app_name, version)?;
     for version in versions.iter() {
         if let Some(executable) = load_or_install(app, version, platform, &output)? {
             println!("{}", executable.0.to_string_lossy());

--- a/src/cmd/which.rs
+++ b/src/cmd/which.rs
@@ -7,8 +7,8 @@ use std::process::ExitCode;
 use super::run::load_or_install;
 
 pub fn which(app_name: &AppName, version: Option<Version>, log: Option<String>) -> Result<ExitCode> {
-    let binding = apps::all();
-    let app = binding.lookup(app_name)?;
+    let apps = apps::all();
+    let app = apps.lookup(app_name)?;
     let output = output::StdErr { category: log };
     let platform = platform::detect(&output)?;
     let versions = RequestedVersions::determine(&app_name, version)?;

--- a/src/cmd/which.rs
+++ b/src/cmd/which.rs
@@ -1,4 +1,7 @@
-use crate::config::{AppName, RequestedVersions};
+use crate::apps;
+use crate::config::AppName;
+use crate::config::RequestedVersions;
+use crate::platform;
 use crate::Output;
 use crate::Result;
 use std::process::ExitCode;
@@ -6,8 +9,11 @@ use std::process::ExitCode;
 use super::run::load_or_install;
 
 pub fn which(app: &AppName, versions: &RequestedVersions, output: &dyn Output) -> Result<ExitCode> {
+    let apps = apps::all();
+    let app = apps.lookup(app)?;
+    let platform = platform::detect(output)?;
     for version in versions.iter() {
-        if let Some(executable) = load_or_install(app, version, output)? {
+        if let Some(executable) = load_or_install(app, version, platform, output)? {
             println!("{}", executable.0.to_string_lossy());
             return Ok(ExitCode::SUCCESS);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,6 @@ fn inner() -> Result<ExitCode> {
         Command::Which { app, version, log } => cmd::which(&app, version, log),
         Command::Update { log } => cmd::update(log),
         Command::Version => Ok(cmd::version()),
-        Command::Versions { app, amount, log } => {
-            let output = output::StdErr { category: log };
-            cmd::versions(&app, amount, &output)
-        }
+        Command::Versions { app, amount, log } => cmd::versions(&app, amount, log),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,11 +34,7 @@ fn main() -> ExitCode {
 fn inner() -> Result<ExitCode> {
     let cli_args = cli::parse(std::env::args())?;
     match cli_args.command {
-        Command::Available { app, version, log } => {
-            let output = output::StdErr { category: log };
-            let versions = RequestedVersions::determine(&app, version)?;
-            cmd::available(&app, &versions, &output)
-        }
+        Command::Available { app, version, log } => cmd::available(&app, version, log),
         Command::RunApp {
             log,
             app,
@@ -47,15 +43,14 @@ fn inner() -> Result<ExitCode> {
             error_on_output,
             optional,
         } => {
-            let output = output::StdErr { category: log };
             let versions = RequestedVersions::determine(&app, version)?;
-            cmd::run(&run::Args {
+            cmd::run(run::Args {
                 app,
                 versions,
                 app_args,
                 error_on_output,
                 optional,
-                output: &output,
+                log,
             })
         }
         Command::DisplayHelp => Ok(cmd::help()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,17 +42,14 @@ fn inner() -> Result<ExitCode> {
             app_args,
             error_on_output,
             optional,
-        } => {
-            let args = run::Args {
-                app,
-                version,
-                app_args,
-                error_on_output,
-                optional,
-                log,
-            };
-            cmd::run(args)
-        }
+        } => cmd::run(run::Args {
+            app,
+            version,
+            app_args,
+            error_on_output,
+            optional,
+            log,
+        }),
         Command::DisplayHelp => Ok(cmd::help()),
         Command::Setup => cmd::setup(),
         Command::Which { app, version, log } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,15 +43,15 @@ fn inner() -> Result<ExitCode> {
             error_on_output,
             optional,
         } => {
-            let versions = RequestedVersions::determine(&app, version)?;
-            cmd::run(run::Args {
+            let args = run::Args {
                 app,
-                versions,
+                version,
                 app_args,
                 error_on_output,
                 optional,
                 log,
-            })
+            };
+            cmd::run(args)
         }
         Command::DisplayHelp => Ok(cmd::help()),
         Command::Setup => cmd::setup(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,10 +52,7 @@ fn inner() -> Result<ExitCode> {
         Command::DisplayHelp => Ok(cmd::help()),
         Command::Setup => cmd::setup(),
         Command::Which { app, version, log } => cmd::which(&app, version, log),
-        Command::Update { log } => {
-            let output = output::StdErr { category: log };
-            cmd::update(&output)
-        }
+        Command::Update { log } => cmd::update(log),
         Command::Version => Ok(cmd::version()),
         Command::Versions { app, amount, log } => {
             let output = output::StdErr { category: log };

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,6 @@ mod yard;
 
 use cli::Command;
 use cmd::run;
-use config::RequestedVersions;
 use error::{Result, UserError};
 use output::Output;
 use std::process::ExitCode;
@@ -52,10 +51,7 @@ fn inner() -> Result<ExitCode> {
         }),
         Command::DisplayHelp => Ok(cmd::help()),
         Command::Setup => cmd::setup(),
-        Command::Which { app, version, log } => {
-            let versions = RequestedVersions::determine(&app, version)?;
-            cmd::which(&app, &versions, log)
-        }
+        Command::Which { app, version, log } => cmd::which(&app, version, log),
         Command::Update { log } => {
             let output = output::StdErr { category: log };
             cmd::update(&output)

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,9 +53,8 @@ fn inner() -> Result<ExitCode> {
         Command::DisplayHelp => Ok(cmd::help()),
         Command::Setup => cmd::setup(),
         Command::Which { app, version, log } => {
-            let output = output::StdErr { category: log };
             let versions = RequestedVersions::determine(&app, version)?;
-            cmd::which(&app, &versions, &output)
+            cmd::which(&app, &versions, log)
         }
         Command::Update { log } => {
             let output = output::StdErr { category: log };


### PR DESCRIPTION
Deriving this data repeatedly in the match clause impairs readability.