### PR TITLE
Make extracted executables executable

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -126,6 +126,9 @@ impl UserError {
       UserError::ArchiveCannotExtract { reason } => {
         error(&format!("cannot extract the archive: {reason}"));
       }
+      UserError::ArchiveDoesNotContainExecutable { expected } => {
+        error(&format!("archive does not contain the expected executable: {expected}"));
+      }
       UserError::CannotAccessConfigFile(reason) => {
         error(&format!("cannot read the config file: {reason}"));
         desc(&format!("please make sure {} is a file and accessible to you", config::FILE_NAME,));
@@ -160,6 +163,7 @@ impl UserError {
         error(&format!("semver range \"{expression}\" is incorrect: {reason}"));
         desc("Please use formats described at https://devhints.io/semver.");
       }
+      UserError::CannotReadFileMetadata { err } => error(&format!("cannot read file metadata: {err}")),
       UserError::CannotReadZipFile { err } => error(&format!("cannot read ZIP file: {err}")),
       UserError::CompilationError { reason } => {
         error(&format!("Compilation error: {reason}"));

--- a/src/error.rs
+++ b/src/error.rs
@@ -167,9 +167,17 @@ impl UserError {
         error(&format!("semver range \"{expression}\" is incorrect: {reason}"));
         desc("Please use formats described at https://devhints.io/semver.");
       }
-      UserError::CannotReadFileMetadata { err } => error(&format!("cannot read file metadata: {err}")),
+      UserError::CannotReadFileMetadata { err } => {
+        error(&format!("cannot read file metadata: {err}"));
+        desc(
+          "This is an issue with your operating system permissions. Please allow the current user to read file permissions for the given path and try again.",
+        );
+      }
       UserError::CannotReadZipFile { err } => error(&format!("cannot read ZIP file: {err}")),
-      UserError::CannotSetFilePermissions { path, err } => error(&format!("cannot write permissions for file {path}: {err}")),
+      UserError::CannotSetFilePermissions { path, err } => {
+        error(&format!("cannot write permissions for file {path}: {err}"));
+        desc("This is an issue with your operating system permissions. Please allow the current user to change permissions for the given path and try again.");
+      }
       UserError::CompilationError { reason } => {
         error(&format!("Compilation error: {reason}"));
       }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ pub enum UserError {
   ArchiveCannotExtract {
     reason: String,
   },
+  #[cfg(unix)]
   ArchiveDoesNotContainExecutable {
     expected: String,
   },
@@ -52,12 +53,14 @@ pub enum UserError {
     expression: String,
     reason: String,
   },
+  #[cfg(unix)]
   CannotReadFileMetadata {
     err: String,
   },
   CannotReadZipFile {
     err: String,
   },
+  #[cfg(unix)]
   CannotSetFilePermissions {
     path: String,
     err: String,
@@ -130,6 +133,7 @@ impl UserError {
       UserError::ArchiveCannotExtract { reason } => {
         error(&format!("cannot extract the archive: {reason}"));
       }
+      #[cfg(unix)]
       UserError::ArchiveDoesNotContainExecutable { expected } => {
         error(&format!("archive does not contain the expected executable: {expected}"));
       }
@@ -167,6 +171,7 @@ impl UserError {
         error(&format!("semver range \"{expression}\" is incorrect: {reason}"));
         desc("Please use formats described at https://devhints.io/semver.");
       }
+      #[cfg(unix)]
       UserError::CannotReadFileMetadata { err } => {
         error(&format!("cannot read file metadata: {err}"));
         desc(
@@ -174,6 +179,7 @@ impl UserError {
         );
       }
       UserError::CannotReadZipFile { err } => error(&format!("cannot read ZIP file: {err}")),
+      #[cfg(unix)]
       UserError::CannotSetFilePermissions { path, err } => {
         error(&format!("cannot write permissions for file {path}: {err}"));
         desc("This is an issue with your operating system permissions. Please allow the current user to change permissions for the given path and try again.");

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,9 @@ pub enum UserError {
   ArchiveCannotExtract {
     reason: String,
   },
+  ArchiveDoesNotContainExecutable {
+    expected: String,
+  },
   CannotAccessConfigFile(String),
   CannotCompileRustSource {
     err: String,
@@ -48,6 +51,9 @@ pub enum UserError {
   CannotParseSemverRange {
     expression: String,
     reason: String,
+  },
+  CannotReadFileMetadata {
+    err: String,
   },
   CannotReadZipFile {
     err: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,6 +58,10 @@ pub enum UserError {
   CannotReadZipFile {
     err: String,
   },
+  CannotSetFilePermissions {
+    path: String,
+    err: String,
+  },
   CompilationError {
     reason: String,
   },
@@ -165,6 +169,7 @@ impl UserError {
       }
       UserError::CannotReadFileMetadata { err } => error(&format!("cannot read file metadata: {err}")),
       UserError::CannotReadZipFile { err } => error(&format!("cannot read ZIP file: {err}")),
+      UserError::CannotSetFilePermissions { path, err } => error(&format!("cannot write permissions for file {path}: {err}")),
       UserError::CompilationError { reason } => {
         error(&format!("Compilation error: {reason}"));
       }

--- a/src/install/download_archive.rs
+++ b/src/install/download_archive.rs
@@ -7,7 +7,6 @@ use crate::prelude::*;
 use crate::yard::Yard;
 use crate::{archives, download};
 use std::fs;
-
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 

--- a/src/install/download_archive.rs
+++ b/src/install/download_archive.rs
@@ -36,14 +36,13 @@ pub fn run(app: &dyn DownloadArchive, version: &Version, platform: Platform, yar
   #[cfg(unix)]
   make_executable_unix(&executable_path_absolute)?;
   #[cfg(windows)]
-  make_executable_windows(&executable_path_absolute)?;
+  make_executable_windows(&executable_path_absolute);
   Ok(Outcome::Installed)
 }
 
 #[cfg(windows)]
-fn make_executable_windows(_filepath: &Path) -> Result<()> {
+fn make_executable_windows(_filepath: &Path) {
   // Windows does not have file permissions --> nothing to do here
-  Ok(())
 }
 
 #[cfg(unix)]

--- a/src/install/download_archive.rs
+++ b/src/install/download_archive.rs
@@ -30,9 +30,12 @@ pub fn run(app: &dyn DownloadArchive, version: &Version, platform: Platform, yar
     return Err(UserError::UnknownArchive(artifact.filename));
   };
   archive.extract_all(&app_folder, log)?;
-  let executable_path = app.executable_path_in_archive(version, platform);
-  let Ok(executable_file) = File::open("foo.txt") else {
-    return Err(UserError::ArchiveDoesNotContainExecutable { expected: executable_path });
+  let executable_path_in_archive = app.executable_path_in_archive(version, platform);
+  let executable_path = app_folder.join(executable_path_in_archive);
+  let Ok(executable_file) = File::open(&executable_path) else {
+    return Err(UserError::ArchiveDoesNotContainExecutable {
+      expected: executable_path.to_string_lossy().to_string(),
+    });
   };
   let metadata = match executable_file.metadata() {
     Ok(metadata) => metadata,

--- a/src/install/download_archive.rs
+++ b/src/install/download_archive.rs
@@ -6,10 +6,10 @@ use crate::platform::Platform;
 use crate::prelude::*;
 use crate::yard::Yard;
 use crate::{archives, download};
+#[cfg(unix)]
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-#[cfg(unix)]
 use std::path::Path;
 
 /// defines the information needed to download and extract an archive containing an app
@@ -35,7 +35,15 @@ pub fn run(app: &dyn DownloadArchive, version: &Version, platform: Platform, yar
   let executable_path_absolute = app_folder.join(executable_path_relative);
   #[cfg(unix)]
   make_executable_unix(&executable_path_absolute)?;
+  #[cfg(windows)]
+  make_executable_windows(&executable_path_absolute)?;
   Ok(Outcome::Installed)
+}
+
+#[cfg(windows)]
+fn make_executable_windows(_filepath: &Path) -> Result<()> {
+  // Windows does not have file permissions --> nothing to do here
+  Ok(())
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Some archives, like `mdbook-linkcheck`, contain an executable that doesn't have the execute bit set. This PR makes the executable file in an extracted archive executable if necessary.