### PR TITLE
Print not-found in yellow

### DIFF
--- a/src/logger/normal.rs
+++ b/src/logger/normal.rs
@@ -28,7 +28,7 @@ pub fn log(event: Event) {
       if is_optional {
         eprintln!("{}", "not found, skipping".yellow());
       } else {
-        eprintln!("{}", "not found".red());
+        eprintln!("{}", "not found".yellow());
       }
     }
 

--- a/src/logger/verbose.rs
+++ b/src/logger/verbose.rs
@@ -28,7 +28,7 @@ pub fn log(event: Event) {
       if is_optional {
         eprintln!("{}", "not found, skipping".yellow());
       } else {
-        eprintln!("{}", "not found".red());
+        eprintln!("{}", "not found".yellow());
       }
     }
 


### PR DESCRIPTION
Printing red when this isn't a critical error causes unnecessary panic attacks.