### PR TITLE
Run auto-fix as part of the test suite

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -19,5 +19,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: make setup
       - run: make test
-      - run: make fix
       - run: git diff HEAD --exit-code --color

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ setup:  # install development dependencies on this computer
 	rustup toolchain add nightly
 	rustup component add rustfmt --toolchain nightly
 
-test: unit lint  # runs all tests
+test: fix unit lint  # runs all tests
 
 unit:  # runs the unit tests
 	cargo test


### PR DESCRIPTION
We keep getting too many CI failures because somebody forgot to format things.