### PR TITLE
Use Ubuntu 22.04 for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,10 @@ jobs:
         include:
           - filename: run_that_app_linux_arm_64
             target: aarch64-unknown-linux-gnu
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - filename: run_that_app_linux_intel_64
             target: x86_64-unknown-linux-gnu
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - filename: run_that_app_macos_arm_64
             target: aarch64-apple-darwin
             os: macos-latest


### PR DESCRIPTION
Ubuntu 20.04 no longer exists: https://github.com/actions/runner-images/issues/11101